### PR TITLE
Remove Gendersternchen and use  generic masculine

### DIFF
--- a/Holacracy-Verfassung.md
+++ b/Holacracy-Verfassung.md
@@ -2,20 +2,20 @@
 
 ## Präambel
 
-Die ***"Ratifizierenden"*** nehmen hiermit diese ***"Verfassung"*** als formale Struktur der Befugnisse der genannten ***"Organisation"*** an. Indem sie dies tun, übertragen die Ratifizierenden ihre Macht, die Organisation zu führen und zu managen, in die Regeln und Prozesse dieser Verfassung, mit Ausnahme jeglicher Macht, für die den Ratifizierenden die Befugnis zur Delegation fehlt. Die Ratifizierenden oder ihre Nachfolger*innen dürfen diese Verfassung ändern oder aufheben, indem sie sich auf dieselbe Befugnis berufen, auf die sie sich bei ihrer Annahme gestützt haben, vorausgesetzt, dass jegliche Änderungen in schriftlicher Form erfolgen.
+Die ***"Ratifizierenden"*** nehmen hiermit diese ***"Verfassung"*** als formale Struktur der Befugnisse der genannten ***"Organisation"*** an. Indem sie dies tun, übertragen die Ratifizierenden ihre Macht, die Organisation zu führen und zu managen, in die Regeln und Prozesse dieser Verfassung, mit Ausnahme jeglicher Macht, für die den Ratifizierenden die Befugnis zur Delegation fehlt. Die Ratifizierenden oder ihre Nachfolger dürfen diese Verfassung ändern oder aufheben, indem sie sich auf dieselbe Befugnis berufen, auf die sie sich bei ihrer Annahme gestützt haben, vorausgesetzt, dass jegliche Änderungen in schriftlicher Form erfolgen.
 
 Jegliche existierenden Richtlinien und Systeme, die wirksam waren, bevor diese Verfassung angenommen wurde, bleiben nach der Annahme in vollem Umfang in Kraft, sie dürfen jedoch nicht erweitert oder modifiziert werden, außer durch die Befugnisse und Prozesse die in dieser Verfassung definiert sind. Diese ehemaligen Richtlinien und Systeme verlieren ferner alles Gewicht und alle Befugnis, sobald durch die Prozesse dieser Verfassung etwas erschaffen wird, das sie ersetzt oder ihnen widerspricht.
 
-Die Organisation darf zusätzlich zu den Ratifizierenden andere ***“Partner\*innen”*** nominieren, um bei ihrer Governance und ihrem operativen Geschäft zu unterstützen, vorausgesetzt, dass jede\*r dieser Partner\*innen ebenfalls zugestimmt hat, alle relevanten Bedingungen dieser Verfassung zu befolgen. Innerhalb dieser Einschränkung darf die Organisation definieren, wie sie Partner\*innenstatus gewährt oder entzieht, sofern es von den Ratifizierenden nicht anders definiert wurde, und die Ratifizierenden dürfen die initialen Partner\*innen für die Organisation definieren.
+Die Organisation darf zusätzlich zu den Ratifizierenden andere ***“Partner”*** nominieren, um bei ihrer Governance und ihrem operativen Geschäft zu unterstützen, vorausgesetzt, dass jeder dieser Partner ebenfalls zugestimmt hat, alle relevanten Bedingungen dieser Verfassung zu befolgen. Innerhalb dieser Einschränkung darf die Organisation definieren, wie sie Partnerstatus gewährt oder entzieht, sofern es von den Ratifizierenden nicht anders definiert wurde, und die Ratifizierenden dürfen die initialen Partner für die Organisation definieren.
 
-Jede\*r Partner\*in darf sich in vollem Maße auf die Befugnisse verlassen, die durch diese Verfassung gewährt werden, in dem vollen Maße, wie die Ratifizierenden solche Befugnisse innehatten, bevor sie sie angenommen haben. Alle Verantwortlichkeiten und Beschränkungen eines Partners oder einer Partnerin stammen aus dieser Verfassung und den Ergebnissen ihrer Prozesse, sowie aus jeglichen rechtlichen Pflichten, die der\*die Partner\*in gegenüber der Organisation hat, solange er\*sie in ihrem Auftrag handelt. Implizite Erwartungen, Beschränkungen oder Gebote, die außerhalb der Befugnis, die durch diese Verfassung gewährt wird, erlassen wurden, haben keinerlei Macht über eine\*n Partner\*in.
+Jeder Partner darf sich in vollem Maße auf die Befugnisse verlassen, die durch diese Verfassung gewährt werden, in dem vollen Maße, wie die Ratifizierenden solche Befugnisse innehatten, bevor sie sie angenommen haben. Alle Verantwortlichkeiten und Beschränkungen eines Partners oder einer Partnerin stammen aus dieser Verfassung und den Ergebnissen ihrer Prozesse, sowie aus jeglichen rechtlichen Pflichten, die der Partner gegenüber der Organisation hat, solange er in ihrem Auftrag handelt. Implizite Erwartungen, Beschränkungen oder Gebote, die außerhalb der Befugnis, die durch diese Verfassung gewährt wird, erlassen wurden, haben keinerlei Macht über einen Partner.
 
 
 ## Artikel 1: Organisationsstruktur
 
 ### 1.1 Definition einer Rolle
 
-Eine ***"Rolle"*** ist ein organisatorisches Konstrukt, das eine Person übernehmen kann und dann im Sinne der Organisation ausübt und ihr Energie verleiht. Jede\*r, der\*die eine Rolle ausfüllt, ist ein\*e ***“Rollen-Lead”*** [Role Lead] für diese Rolle.
+Eine ***"Rolle"*** ist ein organisatorisches Konstrukt, das eine Person übernehmen kann und dann im Sinne der Organisation ausübt und ihr Energie verleiht. Jeder, der eine Rolle ausfüllt, ist ein ***“Rollen-Lead”*** [Role Lead] für diese Rolle.
 
 Eine Rollendefinition besteht aus einem beschreibenden Namen und einem oder mehreren der folgenden Elemente:
 
@@ -66,7 +66,7 @@ Ein innerer Kreis einer Rolle wird als ein ***"Sub-Kreis"*** des umfassenderen K
 
 #### 1.3.2 Domänen delegieren
 
-Wenn ein Kreis einer seiner Rollen eine Domäne gewährt, darf jede\*r Rollen-Lead dieser Rolle die Domäne im Auftrag des Kreises kontrollieren. Ein Kreis darf seinen Rollen nur Domänen gewähren, über die der Kreis bereits verfügt, oder, die nur im Rahmen seiner eigenen internen Prozesse relevant sind.
+Wenn ein Kreis einer seiner Rollen eine Domäne gewährt, darf jeder Rollen-Lead dieser Rolle die Domäne im Auftrag des Kreises kontrollieren. Ein Kreis darf seinen Rollen nur Domänen gewähren, über die der Kreis bereits verfügt, oder, die nur im Rahmen seiner eigenen internen Prozesse relevant sind.
 
 Sobald eine Rolle eine Domäne kontrolliert, darf sie Richtlinien erlassen, die diese Domäne innerhalb ihrer eigenen Governance regulieren. Der Kreis, der die Domäne delegiert hat, behält jedoch das Recht, seine eigenen Richtlinien zu definieren, die diese Domäne ebenfalls regulieren. Im Konfliktfall ersetzen jedwede solcher Richtlinien des Kreises die von der Rolle definierten Richtlinien.
 
@@ -86,46 +86,46 @@ Sobald eine Rolle in einen anderen Kreis verlinkt ist, gilt sie als Teil der Gov
 
 Ein Kreis darf die Verlinkung einer Rolle aufheben, indem er die Richtlinie, die sie zur Verlinkung eingeladen hat, oder einen anderen, in dieser Richtlinie formulierten Mechanismus, wieder entfernt. Auch eine Rolle darf entscheiden, sich selbst wieder aus einem Kreis zu entfernen, in den sie sich verlinkt hat, sofern eine Richtlinie innerhalb der Rolle oder eine, die auf den Super-Kreis der Rolle wirkt, nicht etwas anderes sagt. Sobald die Verlinkung der Rolle mit einem Kreis gelöst wurde, wird jedwede Governance, die der Rolle durch diesen Kreis hinzugefügt wurde, automatisch entfernt.
 
-#### 1.3.5 Prozessmoderator\*in und Kreis-Sekretär\*in Rollen
+#### 1.3.5 Prozessmoderator und Kreis-Sekretär Rollen
 
-Jeder Kreis darf jemanden als den\*die ***“Prozessmoderator\*in”*** [Facilitator] des Kreises berufen. Der\*Die gewählte Prozessmoderator\*in übt eine ***“Prozessmoderator\*in Rolle”*** im Kreis aus mit dem Sinn und Zweck “Kreis-Governance und operative Praktiken im Einklang mit der Verfassung”.
+Jeder Kreis darf jemanden als den ***“Prozessmoderator”*** [Facilitator] des Kreises berufen. Der gewählte Prozessmoderator übt eine ***“Prozessmoderator Rolle”*** im Kreis aus mit dem Sinn und Zweck “Kreis-Governance und operative Praktiken im Einklang mit der Verfassung”.
 
-Jeder Kreis darf jemanden als den\*die ***“Kreis-Sekretär\*in”*** [Secretary] des Kreises berufen. Der\*Die gewählte Kreis-Sekretär\*in übt eine ***“Kreis-Sekretär\*in Rolle”*** im Kreis aus mit dem Sinn und Zweck “Die verfassungsmäßig erforderlichen Aufzeichnungen und Meetings des Kreises stabilisieren.”
+Jeder Kreis darf jemanden als den ***“Kreis-Sekretär”*** [Secretary] des Kreises berufen. Der gewählte Kreis-Sekretär übt eine ***“Kreis-Sekretär Rolle”*** im Kreis aus mit dem Sinn und Zweck “Die verfassungsmäßig erforderlichen Aufzeichnungen und Meetings des Kreises stabilisieren.”
 
-Ein Kreis darf Verantwortlichkeiten oder Domänen zu seiner eigenen Prozessmoderator\*in oder Kreis-Sekretär*in Rolle hinzufügen, sowie diese Zusätze anpassen oder entfernen. Kein Kreis darf den Sinn und Zweck dieser Rollen anpassen oder entfernen, noch irgendwelche Verantwortlichkeiten oder Domänen, die durch die Verfassung in diese Rollen gelegt
+Ein Kreis darf Verantwortlichkeiten oder Domänen zu seiner eigenen Prozessmoderator oder Kreis-Sekretär Rolle hinzufügen, sowie diese Zusätze anpassen oder entfernen. Kein Kreis darf den Sinn und Zweck dieser Rollen anpassen oder entfernen, noch irgendwelche Verantwortlichkeiten oder Domänen, die durch die Verfassung in diese Rollen gelegt
 wurden.
 
 
 ### 1.4 Kreis-Leads
 
-Als ein\*e Rollen-Lead für eine Rolle zu dienen, bedeutet zusätzlich als ein*e ***“Kreis-Lead”*** [Circle Lead] in dem in dieser Rolle enthaltenen [inneren] Kreis zu dienen, und somit die ***"Kreis-Lead Rolle"*** innerhalb dieses Kreises auszuüben. Die Kreis-Lead Rolle hält den gesamten Sinn und Zweck dieser breiteren Rolle, sowie alle Verantwortlichkeiten dieser Rolle, in dem Maße, wie sie nicht durch Rollen oder Prozesse innerhalb des Kreises abgedeckt sind.
+Als ein Rollen-Lead für eine Rolle zu dienen, bedeutet zusätzlich als ein ***“Kreis-Lead”*** [Circle Lead] in dem in dieser Rolle enthaltenen [inneren] Kreis zu dienen, und somit die ***"Kreis-Lead Rolle"*** innerhalb dieses Kreises auszuüben. Die Kreis-Lead Rolle hält den gesamten Sinn und Zweck dieser breiteren Rolle, sowie alle Verantwortlichkeiten dieser Rolle, in dem Maße, wie sie nicht durch Rollen oder Prozesse innerhalb des Kreises abgedeckt sind.
 
 Der Anker-Kreis hat keine Kreis-Leads, sofern keine Richtlinie des Kreises etwas anderes besagt.
 
 
 #### 1.4.1 Rollenzuweisung
 
-Ein\*e Kreis-Lead kontrolliert die Rollenzuweisungs-Domäne und darf jede Rolle innerhalb des Kreises jeder Person zuweisen, die gewillt ist, sie auszuüben, inklusive mehrerer Personen gleichzeitig. Jede Person, die so zugewiesen wurde, darf später aus der Rolle zurücktreten, sofern sie nicht einer anderen Regelung zugestimmt hat. Ein*e Kreis-Lead darf eine Rollenzuweisung für jegliche Rolle innerhalb des Kreises ebenfalls jederzeit zurücknehmen.
+Ein Kreis-Lead kontrolliert die Rollenzuweisungs-Domäne und darf jede Rolle innerhalb des Kreises jeder Person zuweisen, die gewillt ist, sie auszuüben, inklusive mehrerer Personen gleichzeitig. Jede Person, die so zugewiesen wurde, darf später aus der Rolle zurücktreten, sofern sie nicht einer anderen Regelung zugestimmt hat. Ein Kreis-Lead darf eine Rollenzuweisung für jegliche Rolle innerhalb des Kreises ebenfalls jederzeit zurücknehmen.
 
-Ein*e Kreis-Lead darf eine Zuweisung weiter auf einen spezifischen Bereich oder Kontext fokussieren. Dafür muss innerhalb dieses Kontexts die gesamte Rollendefinition immer noch relevant sein. Falls ein Fokus gesetzt wird, verhält sich jeder Zuweisungsfokus wie eine völlig separate Rolle. Der Sinn und Zweck, die Verantwortlichkeiten und die Domänen der Rolle gelten alle weiterhin, jedoch nur innerhalb des Fokus der Zuweisung.
+Ein Kreis-Lead darf eine Zuweisung weiter auf einen spezifischen Bereich oder Kontext fokussieren. Dafür muss innerhalb dieses Kontexts die gesamte Rollendefinition immer noch relevant sein. Falls ein Fokus gesetzt wird, verhält sich jeder Zuweisungsfokus wie eine völlig separate Rolle. Der Sinn und Zweck, die Verantwortlichkeiten und die Domänen der Rolle gelten alle weiterhin, jedoch nur innerhalb des Fokus der Zuweisung.
 
-Niemand anderes als ein\*e Kreis-Lead darf innerhalb des Kreises eine Rolle zuweisen oder entziehen, sofern der Kreis die Zuweisung von Rollen nicht an eine andere Rolle oder einen anderen Prozess delegiert hat. Eine Richtlinie darf Zuweisungen oder Entzug von Rollen weiter einschränken.
+Niemand anderes als ein Kreis-Lead darf innerhalb des Kreises eine Rolle zuweisen oder entziehen, sofern der Kreis die Zuweisung von Rollen nicht an eine andere Rolle oder einen anderen Prozess delegiert hat. Eine Richtlinie darf Zuweisungen oder Entzug von Rollen weiter einschränken.
 
 #### 1.4.2 Unbesetzte Rollen vertreten
 
-Wann immer eine Rolle unbesetzt ist, gilt jede\*r Kreis-Lead automatisch auch als ein*e Rollen-Lead der unbesetzten Rolle.
+Wann immer eine Rolle unbesetzt ist, gilt jeder Kreis-Lead automatisch auch als ein Rollen-Lead der unbesetzten Rolle.
 
-Wenn eine Rolle nur durch Personen ausgeübt wird, die keine Partner\*innen der Organisation sind, dann wird jede\*r Kreis-Lead automatisch auch als ein\*e Rollen-Lead dieser Rolle betrachtet. Diese Standardzuweisung gilt jedoch nur in dem Maße, in dem die Nicht-Partner\*innen die relevanten Verantwortlichkeiten und Pflichten nicht aktiv ausüben, die ein\*e Partner\*in halten würde.
+Wenn eine Rolle nur durch Personen ausgeübt wird, die keine Partner der Organisation sind, dann wird jeder Kreis-Lead automatisch auch als ein Rollen-Lead dieser Rolle betrachtet. Diese Standardzuweisung gilt jedoch nur in dem Maße, in dem die Nicht-Partner die relevanten Verantwortlichkeiten und Pflichten nicht aktiv ausüben, die ein Partner halten würde.
 
 
 #### 1.4.3 Prioritäten und Strategien definieren
 
-Zur Lösung von Prioritätskonflikten zwischen Rollen darf ein\*e Kreis-Lead den relativen Wert möglicher Bestrebungen des Kreises beurteilen. Ein\*e Kreis-Lead darf auch eine ***"Strategie"*** oder mehrere Strategien für den Kreis definieren. Strategien sind Heuristiken, welche die Priorisierung im Kreis leiten.
+Zur Lösung von Prioritätskonflikten zwischen Rollen darf ein Kreis-Lead den relativen Wert möglicher Bestrebungen des Kreises beurteilen. Ein Kreis-Lead darf auch eine ***"Strategie"*** oder mehrere Strategien für den Kreis definieren. Strategien sind Heuristiken, welche die Priorisierung im Kreis leiten.
 
 
 #### 1.4.4 Externe Verweise weiterleiten
 
-Wann immer Governance außerhalb des Kreises auf den Kreis selbst oder irgendeine Rolle darin verweist, darf ein*e Kreis-Lead diesen Verweis aktualisieren und stattdessen auf eine andere Rolle innerhalb des Kreises verweisen. Diese Klarstellung wird nicht als Änderung der Governance dieses Kreises betrachtet.
+Wann immer Governance außerhalb des Kreises auf den Kreis selbst oder irgendeine Rolle darin verweist, darf ein Kreis-Lead diesen Verweis aktualisieren und stattdessen auf eine andere Rolle innerhalb des Kreises verweisen. Diese Klarstellung wird nicht als Änderung der Governance dieses Kreises betrachtet.
 
 #### 1.4.5 Die Kreis-Lead Rolle anpassen
 
@@ -139,64 +139,64 @@ Ein Kreis darf jegliche Verantwortlichkeiten, Domänen, Befugnisse oder Funktion
 
 ### 2.1 Pflicht zur Transparenz
 
-Als Partner\*in hast du gegenüber Rollen-Leads in der Organisation die Pflicht, auf Anfrage Transparenz herzustellen, und zwar wie folgt:
+Als Partner hast du gegenüber Rollen-Leads in der Organisation die Pflicht, auf Anfrage Transparenz herzustellen, und zwar wie folgt:
 
 - **(a) Projekte & nächste Schritte:** Du musst über Projekte und nächste Schritte, die du für die Organisation verfolgst, Auskunft erteilen.
 - **(b) Relative Priorität:** Du musst darüber Auskunft erteilen, wie du die relative Priorität jedes deiner Projekte oder nächsten Schritte im Vergleich zu allem anderen, was deiner Aufmerksamkeit bedarf, beurteilst.
 - **(c) Voraussagen:** Du musst eine Voraussage darüber geben, wann du erwartest, eines der Projekte oder einen der nächsten Schritte abzuschließen. Eine grobe Schätzung unter Einbezug deines aktuellen Kontextes und deiner Prioritäten ist ausreichend. Eine detaillierte Analyse oder Planung ist nicht erforderlich und diese Voraussage ist in keiner Weise eine verbindliche Zusage. Du bist nicht verpflichtet, die Voraussage weiter zu verfolgen oder den Empfänger zu informieren, falls sie sich verändert, sofern die Governance nicht etwas anderes besagt.
-- **(d) Checklisten-Einträge:** Du musst die Erledigung wiederkehrender Aktivitäten überprüfen, die du für deine Rollen oder als Partner\*in der Organisation ausführst. Auf Anfrage musst du diese Überprüfung regelmäßig mitteilen, bis du sie als nicht länger nützlich erachtest.
-- **(e) Kennzahlen:** Du musst über Kennzahlen Auskunft geben, die du in deinen Rollen oder als Partner\*in der Organisation erhebst. Auf Anfrage musst du diese Kennzahlen regelmäßig mitteilen, bis du sie als nicht länger nützlich erachtest.
+- **(d) Checklisten-Einträge:** Du musst die Erledigung wiederkehrender Aktivitäten überprüfen, die du für deine Rollen oder als Partner der Organisation ausführst. Auf Anfrage musst du diese Überprüfung regelmäßig mitteilen, bis du sie als nicht länger nützlich erachtest.
+- **(e) Kennzahlen:** Du musst über Kennzahlen Auskunft geben, die du in deinen Rollen oder als Partner der Organisation erhebst. Auf Anfrage musst du diese Kennzahlen regelmäßig mitteilen, bis du sie als nicht länger nützlich erachtest.
 - **(f) Fortschritts-Updates:** Du musst eine Zusammenfassung des Fortschritts geben, den du in deinen Rollen oder Projekten seit deinem letzten mitgeteilten Update erzielt hast. Auf Anfrage musst du diese Updates so lange regelmäßig teilen, bis du sie als nicht länger nützlich erachtest.
 - **(g) Andere Informationen:** Du musst alle anderen Informationen teilen, die dir leicht zugänglich sind und deren Mitteilung keinen Schaden verursachen würde.
 
 ### 2.2 Pflicht zur Verarbeitung
 
-Als Partner\*in hast du die Pflicht, Nachrichten und Anfragen von anderen Rollen-Leads in der Organisation umgehend wie folgt zu verarbeiten:
+Als Partner hast du die Pflicht, Nachrichten und Anfragen von anderen Rollen-Leads in der Organisation umgehend wie folgt zu verarbeiten:
 
 - **(a) Anfragen zur Klärung:** Andere dürfen dich auffordern, die nächsten Schritte für Projekte oder für Verantwortlichkeiten deiner Rollen zu klären. Du musst dann einen nächsten Schritt definieren und kommunizieren, sofern es einen gibt, den du gehen könntest. Falls es keinen gibt, musst du stattdessen mitteilen, worauf du wartest, bevor du einen nächsten Schritt gehen kannst.
-- **(b) Anfragen nach Projekten und nächsten Schritten:** Andere dürfen dich auffordern, einen bestimmten nächsten Schritt oder ein bestimmtes Projekt in deiner Rolle zu übernehmen. Du musst diese annehmen und verfolgen, sofern du sie in einer deiner Rollen oder als Partner\*in der Organisation für sinnvoll erachtest, unabhängig von anderen Prioritäten. Nimmst du sie nicht an, dann musst du entweder deine Gründe erläutern oder stattdessen etwas anderes vorschlagen, von dem du annimmst, dass es die Zielsetzung der anfragenden Person erfüllt.
+- **(b) Anfragen nach Projekten und nächsten Schritten:** Andere dürfen dich auffordern, einen bestimmten nächsten Schritt oder ein bestimmtes Projekt in deiner Rolle zu übernehmen. Du musst diese annehmen und verfolgen, sofern du sie in einer deiner Rollen oder als Partner der Organisation für sinnvoll erachtest, unabhängig von anderen Prioritäten. Nimmst du sie nicht an, dann musst du entweder deine Gründe erläutern oder stattdessen etwas anderes vorschlagen, von dem du annimmst, dass es die Zielsetzung der anfragenden Person erfüllt.
 - **(c) Anfragen zur Einwirkung auf Domänen:** Andere dürfen verlangen, auf eine Domäne einzuwirken, die du in einer deiner Rollen kontrollierst. Du musst dies zulassen, wenn du keinen Grund siehst, weshalb es dich darin einschränken würde, dem Sinn und Zweck oder den Verantwortlichkeiten deiner Rolle nachzukommen. Wenn du einen solchen Grund siehst, musst du ihn der anfragenden Person erklären.
 
 ### 2.3 Pflicht zur Priorisierung
 
-Als Partner\*in hast du die Pflicht, nach folgenden Gesichtspunkten zu priorisieren, wie du deine Aufmerksamkeit verteilst:
+Als Partner hast du die Pflicht, nach folgenden Gesichtspunkten zu priorisieren, wie du deine Aufmerksamkeit verteilst:
 
 - **(a) Verarbeitung:** Generell musst du die Verarbeitung eingehender Nachrichten von anderen Rollen an deine Rollen höher priorisieren als die Ausführung deiner eigenen nächsten Schritte. Du darfst jedoch die Verarbeitung von Nachrichten verzögern, bis du sie zu einem geeigneten Zeitpunkt gebündelt verarbeiten kannst, solange deine Verarbeitung immer noch zeitnah erfolgt. Verarbeiten umfasst die Erfüllung aller in diesem Artikel genannten Pflichten und auf Anfrage musst du darüber Auskunft erteilen, wie du die Nachricht verarbeitet hast. Verarbeiten umfasst nicht das Abarbeiten der von dir erfassten nächsten Schritte oder Projekte.
-- **(b) Meetings:** Du musst die Teilnahme an einem spezifischen in dieser Verfassung definierten Meeting höher priorisieren als die Durchführung deiner eigenen nächsten Schritte, jedoch nur auf explizite Anfrage anderer Partner\*innen. Du darfst die Anfrage dennoch ablehnen, wenn du für die Zeit des Meetings bereits Pläne hast.
-- **(c) Kreis-Prioritäten:** Bei der Wahl dessen, woran du in einer Rolle arbeiten willst, musst du alle offiziellen Strategien oder relativen Priorisierungen dieser Rolle und aller ihrer Super-Kreise in Betracht ziehen. Du musst diese offiziellen Prioritäten dann als wichtiger für die Organisation betrachten als deine eigenen individuellen Prioritäten, oder deine eigene Beurteilung der Prioritäten der Organisation. Offizielle Prioritäten eines Kreises sind diejenigen, die von einem\*r Kreis-Lead oder von anderen Rollen oder Prozessen definiert werden, die befugt sind, Prioritätskonflikte zu lösen und Strategien für diesen Kreis zu definieren.
-- **(d) Deadlines:** Falls die Governance Aufzeichnungen oder irgendeine offizielle Strategie oder Priorisierung eines Kreises eine Deadline enthält, die definiert, bis wann etwas getan werden muss, so darf niemand das als ein Mandat interpretieren, diese Deadline ohne Rücksicht auf die Auswirkungen einer solchen Entscheidung zu erfüllen. Stattdessen musst du sie als eine offizielle Priorisierung aller Schritte interpretieren, die erforderlich sind, um diese Deadline einzuhalten, relativ zu allen anderen Schritten dieses Kreises, und entsprechend handeln. Ein*e Kreis-Lead, oder eine andere Rolle, oder ein Prozess mit der Befugnis rollenübergreifende Prioritätskonflikte zu lösen, darf diese Priorisierung aufheben.
+- **(b) Meetings:** Du musst die Teilnahme an einem spezifischen in dieser Verfassung definierten Meeting höher priorisieren als die Durchführung deiner eigenen nächsten Schritte, jedoch nur auf explizite Anfrage anderer Partner. Du darfst die Anfrage dennoch ablehnen, wenn du für die Zeit des Meetings bereits Pläne hast.
+- **(c) Kreis-Prioritäten:** Bei der Wahl dessen, woran du in einer Rolle arbeiten willst, musst du alle offiziellen Strategien oder relativen Priorisierungen dieser Rolle und aller ihrer Super-Kreise in Betracht ziehen. Du musst diese offiziellen Prioritäten dann als wichtiger für die Organisation betrachten als deine eigenen individuellen Prioritäten, oder deine eigene Beurteilung der Prioritäten der Organisation. Offizielle Prioritäten eines Kreises sind diejenigen, die von einem Kreis-Lead oder von anderen Rollen oder Prozessen definiert werden, die befugt sind, Prioritätskonflikte zu lösen und Strategien für diesen Kreis zu definieren.
+- **(d) Deadlines:** Falls die Governance Aufzeichnungen oder irgendeine offizielle Strategie oder Priorisierung eines Kreises eine Deadline enthält, die definiert, bis wann etwas getan werden muss, so darf niemand das als ein Mandat interpretieren, diese Deadline ohne Rücksicht auf die Auswirkungen einer solchen Entscheidung zu erfüllen. Stattdessen musst du sie als eine offizielle Priorisierung aller Schritte interpretieren, die erforderlich sind, um diese Deadline einzuhalten, relativ zu allen anderen Schritten dieses Kreises, und entsprechend handeln. Ein Kreis-Lead, oder eine andere Rolle, oder ein Prozess mit der Befugnis rollenübergreifende Prioritätskonflikte zu lösen, darf diese Priorisierung aufheben.
 
 ### 2.4 Beziehungsvereinbarungen
 
-Als Partner\*in darfst du ***“Beziehungsvereinbarungen”*** [Relational Agreements] mit anderen Partner\*innen schließen. Dies sind Vereinbarungen darüber, wie die Partner\*innen ihre Beziehung pflegen wollen oder sie ihre generellen Funktionen als Partner\*innen der Organisation erfüllen wollen. Diese Vereinbarungen dürfen die Pflichten in diesem Artikel ergänzen oder klären, doch sie dürfen diesen nicht zuwiderlaufen.
+Als Partner darfst du ***“Beziehungsvereinbarungen”*** [Relational Agreements] mit anderen Partner schließen. Dies sind Vereinbarungen darüber, wie die Partner ihre Beziehung pflegen wollen oder sie ihre generellen Funktionen als Partner der Organisation erfüllen wollen. Diese Vereinbarungen dürfen die Pflichten in diesem Artikel ergänzen oder klären, doch sie dürfen diesen nicht zuwiderlaufen.
 
-Beziehungsvereinbarungen dürfen sich nur auf die Formulierung von Verhaltensweisen konzentrieren, welche allgemein die Arbeit unterstützen. Sie dürfen weder Erwartungen über rollenbezogene Arbeit aufstellen, noch Erwartungen darüber, wie ein\*e Partner\*in  übergreifend zwischen verschiedenen Rollen priorisieren wird. Ferner dürfen sie nur konkrete, ausführbare Handlungen, oder zu beachtende Einschränkungen des Verhaltens bestimmen. Sie dürfen keine Versprechen enthalten, bestimmte Ergebnisse zu erreichen oder abstrakte Qualitäten zu verkörpern.
+Beziehungsvereinbarungen dürfen sich nur auf die Formulierung von Verhaltensweisen konzentrieren, welche allgemein die Arbeit unterstützen. Sie dürfen weder Erwartungen über rollenbezogene Arbeit aufstellen, noch Erwartungen darüber, wie ein Partner  übergreifend zwischen verschiedenen Rollen priorisieren wird. Ferner dürfen sie nur konkrete, ausführbare Handlungen, oder zu beachtende Einschränkungen des Verhaltens bestimmen. Sie dürfen keine Versprechen enthalten, bestimmte Ergebnisse zu erreichen oder abstrakte Qualitäten zu verkörpern.
 
-Als Partner\*in darfst du aufgrund deiner eigenen persönlichen Präferenzen, oder um deiner Rolle zu dienen, eine Beziehungsvereinbarung von anderen Partner\*innen anfragen. Diese Partner\*innen dürfen die angefragte Beziehungsvereinbarung auf der Basis ihrer eigenen persönlichen Präferenzen annehmen oder ablehnen. Jede Partei darf die Vereinbarung später beenden, indem sie die jeweils andere Partei darüber in Kenntnis setzt, sofern es nicht anders vereinbart wurde.
+Als Partner darfst du aufgrund deiner eigenen persönlichen Präferenzen, oder um deiner Rolle zu dienen, eine Beziehungsvereinbarung von anderen Partner anfragen. Diese Partner dürfen die angefragte Beziehungsvereinbarung auf der Basis ihrer eigenen persönlichen Präferenzen annehmen oder ablehnen. Jede Partei darf die Vereinbarung später beenden, indem sie die jeweils andere Partei darüber in Kenntnis setzt, sofern es nicht anders vereinbart wurde.
 
-Als Partner\*in hast du die Pflicht, dich in deinem Verhalten nach allen auf diese Weise geschlossenen, schriftlich festgehaltenen, Beziehungsvereinbarungen zu richten. Alle, die ein Meeting oder einen Prozess moderieren, dürfen diese Beziehungsvereinbarungen in diesem Meeting oder Prozess ebenfalls geltend machen, solange sie nicht im Widerspruch zu dieser Verfassung stehen.
+Als Partner hast du die Pflicht, dich in deinem Verhalten nach allen auf diese Weise geschlossenen, schriftlich festgehaltenen, Beziehungsvereinbarungen zu richten. Alle, die ein Meeting oder einen Prozess moderieren, dürfen diese Beziehungsvereinbarungen in diesem Meeting oder Prozess ebenfalls geltend machen, solange sie nicht im Widerspruch zu dieser Verfassung stehen.
 
 ## Artikel 3: Tactical Meetings
 
-Jede\*r Partner\*in darf ein ***“Tactical Meeting”*** einberufen, um Partner\*innen dabei zu unterstützen, einander in ihren Verantwortlichkeiten und Pflichten in Anspruch zu nehmen. Zusätzlich ist die Rolle Kreis-Sekretär\*in jedes Kreises dafür zuständig, reguläre Tactical Meetings für den Kreis anzusetzen.
+Jeder Partner darf ein ***“Tactical Meeting”*** einberufen, um Partner dabei zu unterstützen, einander in ihren Verantwortlichkeiten und Pflichten in Anspruch zu nehmen. Zusätzlich ist die Rolle Kreis-Sekretär jedes Kreises dafür zuständig, reguläre Tactical Meetings für den Kreis anzusetzen.
 
 ### 3.1 Teilnahme
 
-Zu regulären Tactical Meetings, die von der Rolle Kreis-Sekretär\*in einberufen werden, sind alle Rollen des Kreises eingeladen, sofern eine Richtlinie nicht etwas anderes besagt. Für andere Tactical Meetings muss der\*die das Meeting einberufende Partner\*in, definieren, welche Rollen zu diesem Meeting eingeladen sind. Alle Partner\*innen, die als Rollen-Leads dieser Rollen dienen, sind dann eingeladen teilzunehmen und diese Rollen zu vertreten, sofern der\*die Einladende die Einladung nicht auf nur einen Teil der Rollen-Leads einer Rolle begrenzt.
+Zu regulären Tactical Meetings, die von der Rolle Kreis-Sekretär einberufen werden, sind alle Rollen des Kreises eingeladen, sofern eine Richtlinie nicht etwas anderes besagt. Für andere Tactical Meetings muss der das Meeting einberufende Partner, definieren, welche Rollen zu diesem Meeting eingeladen sind. Alle Partner, die als Rollen-Leads dieser Rollen dienen, sind dann eingeladen teilzunehmen und diese Rollen zu vertreten, sofern der Einladende die Einladung nicht auf nur einen Teil der Rollen-Leads einer Rolle begrenzt.
 
 ### 3.2 Meeting Prozess
 
-Die Rolle Prozessmoderator\*in eines Kreises ist dafür zuständig, die regulären Tactical Meetings des Kreises zu moderieren, und sein\*e Kreis-Sekretär\*in ist dafür zuständig, die Ergebnisse dieser Tactical Meetings zu erfassen und zu veröffentlichen. Für Tactical Meetings, die von jemand anderem als der Rolle Kreis-Sekretär\*in einberufen wurden, muss moderieren, wer das Tactical Meeting einberufen hat. Diese Person muss auch die Ergebnisse erfassen, oder eine\*n Freiwillige\*n oder eine angemessene Rolle dafür gewinnen.
+Die Rolle Prozessmoderator eines Kreises ist dafür zuständig, die regulären Tactical Meetings des Kreises zu moderieren, und sein Kreis-Sekretär ist dafür zuständig, die Ergebnisse dieser Tactical Meetings zu erfassen und zu veröffentlichen. Für Tactical Meetings, die von jemand anderem als der Rolle Kreis-Sekretär einberufen wurden, muss moderieren, wer das Tactical Meeting einberufen hat. Diese Person muss auch die Ergebnisse erfassen, oder einen Freiwilligen oder eine angemessene Rolle dafür gewinnen.
 
 Wenn keine Richtlinie etwas anderes besagt, muss die Person, die das Meeting moderiert, den folgenden Prozess nutzen:
 
-- **(a) Check-in Runde:** Alle Teilnehmenden äußern der Reihe nach ihr aktuelles Befinden, oder teilen einen anderen Wortbeitrag zur Eröffnung des Meetings. Reaktionen sind nicht erlaubt.
-- **(b) Checklisten Durchsicht:** Alle Teilnehmenden überprüfen den Abschluss jeglicher wiederkehrender Aktivitäten, über die sie regelmäßig für ihre Rollen im Meeting berichten.
-- **(c) Kennzahlen Durchsicht:** Alle Teilnehmenden teilen jegliche Kennzahlen mit, über die sie regelmäßig für ihre Rollen im Meeting berichten.
-- **(d) Erzielte Fortschritte:** Alle Teilnehmenden heben Fortschritte in jeglichen Projekten oder anderen Initiativen hervor, über die sie regelmäßig für ihre Rollen im Meeting berichten. Die Teilnehmenden dürfen nur den Fortschritt gegenüber dem vorigen Bericht mitteilen und nicht den generellen Status einer Arbeit.
-- **(e) Agenda erstellen:** Die Teilnehmenden erstellen eine Agenda der Punkte, die während des Meetings verarbeitet werden sollen. Jede\*r Teilnehmende darf so viele Agendapunkte hinzufügen, wie gewünscht, indem er*sie einen kurzen Platzhalter für jeden Punkt nennt, wobei keine Erklärung oder Diskussion erlaubt ist. Teilnehmende dürfen nach diesem Schritt, zwischen der Verarbeitung bereits bestehender Agendapunkte, noch weitere Agendapunkte hinzufügen.
-- **(f) Spannungen verarbeiten:** Wer einen Agendapunkt eingebracht hat, darf, um diesen zu bearbeiten, Anfragen an andere Teilnehmende richten, entweder in ihrer allgemeinen Eigenschaft als Partner\*in, oder in einer Rolle, die diese\*r Teilnehmende im Meeting repräsentiert. Anfragen an eine Rolle dürfen jedoch nur im Dienste einer Rolle gemacht werden, die der\*die Anfragende im Meeting repräsentiert. Die Person, die das Meeting moderiert, managt die Zeit für jeden Agendapunkt. Um Raum für die gesamte Agenda zu erlauben, darf sie, nach einem angemessenen Anteil der Meetingzeit, die Verarbeitung jedes Punktes abbrechen.
-- **(g) Abschlussrunde:** Alle Teilnehmenden äußern der Reihe nach eine Abschlussreflektion in Bezug auf das Meeting. Reaktionen sind nicht erlaubt.
+- **(a) Check-in Runde:** Alle Teilnehmer äußern der Reihe nach ihr aktuelles Befinden, oder teilen einen anderen Wortbeitrag zur Eröffnung des Meetings. Reaktionen sind nicht erlaubt.
+- **(b) Checklisten Durchsicht:** Alle Teilnehmer überprüfen den Abschluss jeglicher wiederkehrender Aktivitäten, über die sie regelmäßig für ihre Rollen im Meeting berichten.
+- **(c) Kennzahlen Durchsicht:** Alle Teilnehmer teilen jegliche Kennzahlen mit, über die sie regelmäßig für ihre Rollen im Meeting berichten.
+- **(d) Erzielte Fortschritte:** Alle Teilnehmer heben Fortschritte in jeglichen Projekten oder anderen Initiativen hervor, über die sie regelmäßig für ihre Rollen im Meeting berichten. Die Teilnehmer dürfen nur den Fortschritt gegenüber dem vorigen Bericht mitteilen und nicht den generellen Status einer Arbeit.
+- **(e) Agenda erstellen:** Die Teilnehmer erstellen eine Agenda der Punkte, die während des Meetings verarbeitet werden sollen. Jeder Teilnehmer darf so viele Agendapunkte hinzufügen, wie gewünscht, indem er einen kurzen Platzhalter für jeden Punkt nennt, wobei keine Erklärung oder Diskussion erlaubt ist. Teilnehmer dürfen nach diesem Schritt, zwischen der Verarbeitung bereits bestehender Agendapunkte, noch weitere Agendapunkte hinzufügen.
+- **(f) Spannungen verarbeiten:** Wer einen Agendapunkt eingebracht hat, darf, um diesen zu bearbeiten, Anfragen an andere Teilnehmer richten, entweder in ihrer allgemeinen Eigenschaft als Partner, oder in einer Rolle, die dieser Teilnehmer im Meeting repräsentiert. Anfragen an eine Rolle dürfen jedoch nur im Dienste einer Rolle gemacht werden, die der Anfragende im Meeting repräsentiert. Die Person, die das Meeting moderiert, managt die Zeit für jeden Agendapunkt. Um Raum für die gesamte Agenda zu erlauben, darf sie, nach einem angemessenen Anteil der Meetingzeit, die Verarbeitung jedes Punktes abbrechen.
+- **(g) Abschlussrunde:** Alle Teilnehmer äußern der Reihe nach eine Abschlussreflektion in Bezug auf das Meeting. Reaktionen sind nicht erlaubt.
 
 Eine Richtlinie eines Kreises darf einen alternativen Prozess definieren oder diesen Standardprozess für Tactical Meetings, die von jeder der Rollen des Kreises einberufen werden können, anpassen.
 
@@ -221,35 +221,35 @@ Du darfst zudem auf jede Domäne eines Kreises einwirken, der deine Rolle enthä
 
 Du darfst keine Kontrolle über eine Domäne ausüben oder materiell auf eine Domäne einwirken, die an eine Rolle oder einen Kreis delegiert wurde, der deine Rolle nicht enthält, es sei denn, du bekommst dafür Erlaubnis. Auch darfst du dasselbe nicht ohne Erlaubnis in Bezug auf eine Domäne tun, die einer anderen unabhängigen Partei gehört.
 
-Wenn du Erlaubnis benötigst, um auf eine Domäne einzuwirken, darfst du sie dir von jedem\*r einholen, der\*die diese Domäne kontrolliert. Du darfst dir die Erlaubnis auch einholen, indem du deine Absicht mitteilst, eine spezifische Handlung auszuführen, und jeden mit einer relevanten Domäne einlädst, einen Einwand zu erheben. Du musst dann eine angemessene Zeit warten, um Antworten zu erlauben. Falls in dieser Zeit niemand einen Einwand erhebt, dann hast du die Erlaubnis, auf jede Domäne einer Rolle in der Organisation, die deine Ankündigung erreicht hat, einzuwirken. Du darfst annehmen, dass eine schriftliche Ankündigung jede\*n erreicht hat, der\*die normalerweise Nachrichten in dem Kanal liest, den du benutzt hast. Eine Erlaubnis, die auf diese Weise gewährt wird, gilt nur für die spezifische Handlung, die du angekündigt hast. Eine Richtlinie darf diesen Prozess ändern oder einschränken.
+Wenn du Erlaubnis benötigst, um auf eine Domäne einzuwirken, darfst du sie dir von jedem einholen, der diese Domäne kontrolliert. Du darfst dir die Erlaubnis auch einholen, indem du deine Absicht mitteilst, eine spezifische Handlung auszuführen, und jeden mit einer relevanten Domäne einlädst, einen Einwand zu erheben. Du musst dann eine angemessene Zeit warten, um Antworten zu erlauben. Falls in dieser Zeit niemand einen Einwand erhebt, dann hast du die Erlaubnis, auf jede Domäne einer Rolle in der Organisation, die deine Ankündigung erreicht hat, einzuwirken. Du darfst annehmen, dass eine schriftliche Ankündigung jeden erreicht hat, der normalerweise Nachrichten in dem Kanal liest, den du benutzt hast. Eine Erlaubnis, die auf diese Weise gewährt wird, gilt nur für die spezifische Handlung, die du angekündigt hast. Eine Richtlinie darf diesen Prozess ändern oder einschränken.
 
 #### 4.1.3 Hole Befugnis ein, bevor du Ausgaben tätigst
 
 Du darfst keinerlei Geld oder andere Vermögenswerte ausgeben, außer, du hast zuvor die Befugnis bekommen, es zu tun. Diese Befugnis muss von einer Rolle kommen, die bereits die Kontrolle über diese Ressourcen für Ausgabenzwecke hat. Es zählt als Ausgabe, wenn du bedeutende Vermögenswerte der Organisation veräußerst, oder irgendeines ihrer Rechte auf bedeutende Weise einschränkst.
 
-Um eine Ausgabebefugnis zu bekommen, musst du deine Absicht, eine Ausgabe zu tätigen, der Rolle, von der du die Befugnis ersuchst, schriftlich ankündigen. Du musst diese Ankündigung dort teilen, wo alle Partner\*innen, die als Rollen-Leads dieser Rolle oder in dieser Rolle dienen, sie normalerweise sehen werden. Deine Erklärung muss den Grund für die Ausgabe nennen, und die Rolle, aus der du die Ausgabe tätigen wirst. Du musst dann eine angemessene Zeit warten, um Abwägung und Antworten zuzulassen. Jede\*r Empfänger\*in deiner Ankündigung darf die Ausgabe für zusätzliche Abwägung eskalieren, und du darfst nicht mit der Ausgabe fortfahren, wenn sie eskaliert worden ist. Ein\*e Rollen-Lead der Rolle, von der du Befugnis suchst, darf jedoch eine Eskalation wieder zurücknehmen, ebenso wie die Person, die eskaliert hat. Sobald eine angemessene Zeit vergangen ist und keine Eskalation besteht, gewinnt deine Rolle Kontrolle über diese Ressourcen. Du darfst sie für den angegebenen Zweck ausgeben, oder zudem anderen diese Befugnis erteilen. Die Rolle, von der du diese Befugnis erhalten hast, verliert diese Kontrolle hingegen. Ein*e Rollen-Lead dieser Rolle darf diese Befugnis jedoch jederzeit zurücknehmen.
+Um eine Ausgabebefugnis zu bekommen, musst du deine Absicht, eine Ausgabe zu tätigen, der Rolle, von der du die Befugnis ersuchst, schriftlich ankündigen. Du musst diese Ankündigung dort teilen, wo alle Partner, die als Rollen-Leads dieser Rolle oder in dieser Rolle dienen, sie normalerweise sehen werden. Deine Erklärung muss den Grund für die Ausgabe nennen, und die Rolle, aus der du die Ausgabe tätigen wirst. Du musst dann eine angemessene Zeit warten, um Abwägung und Antworten zuzulassen. Jeder Empfänger deiner Ankündigung darf die Ausgabe für zusätzliche Abwägung eskalieren, und du darfst nicht mit der Ausgabe fortfahren, wenn sie eskaliert worden ist. Ein Rollen-Lead der Rolle, von der du Befugnis suchst, darf jedoch eine Eskalation wieder zurücknehmen, ebenso wie die Person, die eskaliert hat. Sobald eine angemessene Zeit vergangen ist und keine Eskalation besteht, gewinnt deine Rolle Kontrolle über diese Ressourcen. Du darfst sie für den angegebenen Zweck ausgeben, oder zudem anderen diese Befugnis erteilen. Die Rolle, von der du diese Befugnis erhalten hast, verliert diese Kontrolle hingegen. Ein Rollen-Lead dieser Rolle darf diese Befugnis jedoch jederzeit zurücknehmen.
 
 Eine Richtlinie darf diesen Prozess auf jegliche Weise verändern, oder einer Rolle direkt die Befugnis erteilen, die Ausgaben der Ressourcen des Kreises zu kontrollieren.
 
 ### 4.2 Befugnis zur Auslegung
 
-Als Partner\*in darfst du deinen gesunden Menschenverstand nutzen, um diese Verfassung und alles innerhalb ihrer Befugnisse auszulegen. Ferner darfst du auslegen, wie diese Regeln in einer spezifischen Situation, mit der du konfrontiert bist, anzuwenden sind und gemäß deiner Auslegung handeln. Du musst jedoch die gesamte Governance im Kontext des Sinn und Zwecks, sowie der Verantwortlichkeiten desjenigen Kreises auslegen, der sie enthält. Darüber hinaus musst du alle offiziellen Auslegungsentscheidungen dieses Kreises, bzw. aller Super-Kreise davon berücksichtigen. Du darfst keine Auslegungen verwenden, die im Widerspruch zu diesem Kontext oder diesen Entscheidungen stehen.
+Als Partner darfst du deinen gesunden Menschenverstand nutzen, um diese Verfassung und alles innerhalb ihrer Befugnisse auszulegen. Ferner darfst du auslegen, wie diese Regeln in einer spezifischen Situation, mit der du konfrontiert bist, anzuwenden sind und gemäß deiner Auslegung handeln. Du musst jedoch die gesamte Governance im Kontext des Sinn und Zwecks, sowie der Verantwortlichkeiten desjenigen Kreises auslegen, der sie enthält. Darüber hinaus musst du alle offiziellen Auslegungsentscheidungen dieses Kreises, bzw. aller Super-Kreise davon berücksichtigen. Du darfst keine Auslegungen verwenden, die im Widerspruch zu diesem Kontext oder diesen Entscheidungen stehen.
 
 #### 4.2.1 Auslegungskonflikte
 
-Als Partner\*in kann deine Auslegung dieser Verfassung und der Governance der Organisation manchmal mit der eines\*r anderen Partners\*in im Konflikt stehen. Falls das geschieht, darf jede der beiden Parteien die Rolle Kreis-Sekretär\*in jedes betroffenen Kreises bitten, darüber zu entscheiden, welche Auslegung anzuwenden ist. Nachdem die Rolle Kreis-Sekretär\*in geantwortet hat, muss sich jede\*r nach der Entscheidung der Rolle Kreis-Sekretär\*in richten, bis der relevante Text oder Kontext sich ändert.
+Als Partner kann deine Auslegung dieser Verfassung und der Governance der Organisation manchmal mit der eines anderen Partners im Konflikt stehen. Falls das geschieht, darf jede der beiden Parteien die Rolle Kreis-Sekretär jedes betroffenen Kreises bitten, darüber zu entscheiden, welche Auslegung anzuwenden ist. Nachdem die Rolle Kreis-Sekretär geantwortet hat, muss sich jeder nach der Entscheidung der Rolle Kreis-Sekretär richten, bis der relevante Text oder Kontext sich ändert.
 
-Nach einer Entscheidung über eine Auslegung kann ein\*e Kreis-Sekretär\*in die Entscheidung und die ihr zugrundeliegende Logik publizieren. Wenn sie veröffentlicht wird, müssen der\*die Kreis-Sekretär\*in dieses Kreises und aller darin enthaltenen Kreise versuchen, sich in allen zukünftigen Entscheidungen nach dieser Logik zu richten. Ein\*e Kreis-Sekretär\*in darf ihr jedoch immer noch widersprechen, sobald ein überzeugender neuer Sachverhalt die Logik obsolet macht.
+Nach einer Entscheidung über eine Auslegung kann ein Kreis-Sekretär die Entscheidung und die ihr zugrundeliegende Logik publizieren. Wenn sie veröffentlicht wird, müssen der Kreis-Sekretär dieses Kreises und aller darin enthaltenen Kreise versuchen, sich in allen zukünftigen Entscheidungen nach dieser Logik zu richten. Ein Kreis-Sekretär darf ihr jedoch immer noch widersprechen, sobald ein überzeugender neuer Sachverhalt die Logik obsolet macht.
 
-Du darfst bei dem\*der Kreis-Sekretär\*in jedes Super-Kreises Berufung gegen die Auslegung eines\*r Kreis-Sekretärs\*in einlegen. Der\*Die Kreis-Sekretär\*in eines Super-Kreises darf die Auslegung jede\*s Kreis-Sekretärs\*in eines Sub-Kreises aufheben.
+Du darfst bei dem Kreis-Sekretär jedes Super-Kreises Berufung gegen die Auslegung eines Kreis-Sekretärs einlegen. Der Kreis-Sekretär eines Super-Kreises darf die Auslegung jedes Kreis-Sekretärs eines Sub-Kreises aufheben.
 
 #### 4.2.2 Ungültige Governance streichen
 
-Jede\*r Partner\*in darf die Rolle Kreis-Sekretär\*in eines Kreises anfragen, über die Gültigkeit der Governance innerhalb dieses Kreises oder irgendeines seiner Sub-Kreises zu urteilen. Falls der\*die Kreis-Sekretär\*in zu dem Schluss kommt, dass sie die Regeln dieser Verfassung verletzt, muss er\*sie diese aus den Aufzeichnungen des Kreises streichen. Danach muss er\*sie allen Partner/*innen, die Rollen in diesem Kreis ausüben, umgehend mitteilen, was er\*sie gestrichen hat und warum.
+Jeder Partner darf die Rolle Kreis-Sekretär eines Kreises anfragen, über die Gültigkeit der Governance innerhalb dieses Kreises oder irgendeines seiner Sub-Kreises zu urteilen. Falls der Kreis-Sekretär zu dem Schluss kommt, dass sie die Regeln dieser Verfassung verletzt, muss er diese aus den Aufzeichnungen des Kreises streichen. Danach muss er allen Partner/*innen, die Rollen in diesem Kreis ausüben, umgehend mitteilen, was er gestrichen hat und warum.
 
 ### 4.3 Individuelle Initiative
 
-Als Partner\*in bist du in manchen Fällen befugt, ***“individuelle Initiative”*** [individual initiative] zu ergreifen, indem du außerhalb der Befugnis deiner Rollen handelst oder indem du Regeln dieser Verfassung brichst.
+Als Partner bist du in manchen Fällen befugt, ***“individuelle Initiative”*** [individual initiative] zu ergreifen, indem du außerhalb der Befugnis deiner Rollen handelst oder indem du Regeln dieser Verfassung brichst.
 
 #### 4.3.1 Erlaubte Situationen
 
@@ -262,41 +262,41 @@ Du darfst nur dann individuelle Initiative ergreifen, wenn alle der folgenden Be
 
 #### 4.3.2 Kommunikation und Wiederherstellung
 
-Nachdem du individuelle Initiative ergriffen hast, musst du deine Handlung gegenüber allen Rollen-Leads erklären, von denen du glaubst, dass sie signifikant davon betroffen sein könnten. Auf Anfrage eines\*r betroffenen Rollen-Lead*s musst du weitere Schritte ausführen, um jegliche Spannungen lösen zu helfen, die durch deine individuelle Initiative entstanden sind. Zudem musst du auf Verlangen eines\*r solchen Rollen-Lead\*s in Zukunft davon absehen, eine ähnliche individuelle Initiative zu ergreifen.
+Nachdem du individuelle Initiative ergriffen hast, musst du deine Handlung gegenüber allen Rollen-Leads erklären, von denen du glaubst, dass sie signifikant davon betroffen sein könnten. Auf Anfrage eines betroffenen Rollen-Leads musst du weitere Schritte ausführen, um jegliche Spannungen lösen zu helfen, die durch deine individuelle Initiative entstanden sind. Zudem musst du auf Verlangen eines solchen Rollen-Leads in Zukunft davon absehen, eine ähnliche individuelle Initiative zu ergreifen.
 
-Du musst die Kommunikation und Wiederherstellung, die in diesem Abschnitt gefordert werden, gegenüber deiner gewöhnlichen Arbeit vorziehen. Der\*Die Kreis-Lead eines Kreises, der alle von deinen Handlungen betroffenen Rollen enthält, darf diese standardmäßige Priorisierung jedoch ändern.
+Du musst die Kommunikation und Wiederherstellung, die in diesem Abschnitt gefordert werden, gegenüber deiner gewöhnlichen Arbeit vorziehen. Der Kreis-Lead eines Kreises, der alle von deinen Handlungen betroffenen Rollen enthält, darf diese standardmäßige Priorisierung jedoch ändern.
 
 ## Artikel 5: Governance Prozess
 
 Die Änderung der Governance eines Kreises erfordert die Anwendung des hier definierten ***"Governance-Prozesses"***.
 
-### 5.1 Governance Teilnehmende
+### 5.1 Governance Teilnehmer
 
 Jeder Kreis hat eine Gruppe von ***"Kreismitgliedern"***, die seine Rollen in seinem Governance-Prozess vertreten dürfen.
 
-Die Kreismitglieder eines Kreises sind diejenigen Partner\*innen, die seine Kreis-Lead Rolle ausüben, sowie alle Partner\*innen, die als Rollen-Lead für eine Rolle im Kreis dienen. Falls eine Rolle mehrere Rollen-Leads hat, darf ein Kreis eine Richtlinie erlassen, um zu begrenzen, wie viele von ihnen diese Rolle als Kreismitglieder in seinem Governance Prozess vertreten dürfen.
+Die Kreismitglieder eines Kreises sind diejenigen Partner, die seine Kreis-Lead Rolle ausüben, sowie alle Partner, die als Rollen-Lead für eine Rolle im Kreis dienen. Falls eine Rolle mehrere Rollen-Leads hat, darf ein Kreis eine Richtlinie erlassen, um zu begrenzen, wie viele von ihnen diese Rolle als Kreismitglieder in seinem Governance Prozess vertreten dürfen.
 
 
 #### 5.1.1 Kreis Reps
 
-Jedes Kreismitglied eines Kreises darf jederzeit eine Wahl anfordern, um jemanden als ***„Kreis-Rep“*** [Circle Rep] des Kreises zu wählen oder zu ersetzen, um diesen Kreis in jedem umfassenderen Kreis unterstützend zu vertreten, der ihn enthält. Der\*Die gewählte Kreis-Rep übt eine ***„Kreis-Rep Rolle”*** im Kreis aus, mit dem Sinn und Zweck, “Für die Verarbeitung im umfassenderen Kreis relevante Spannungen sind nach außen geleitet und gelöst”, und den folgenden Verantwortlichkeiten:
+Jedes Kreismitglied eines Kreises darf jederzeit eine Wahl anfordern, um jemanden als ***„Kreis-Rep“*** [Circle Rep] des Kreises zu wählen oder zu ersetzen, um diesen Kreis in jedem umfassenderen Kreis unterstützend zu vertreten, der ihn enthält. Der gewählte Kreis-Rep übt eine ***„Kreis-Rep Rolle”*** im Kreis aus, mit dem Sinn und Zweck, “Für die Verarbeitung im umfassenderen Kreis relevante Spannungen sind nach außen geleitet und gelöst”, und den folgenden Verantwortlichkeiten:
 
 - **(a)** Versuchen, Spannungen zu verstehen, die von Rollen-Leads innerhalb des Kreises mitgeteilt werden
 - **(b)** Spannungen identifizieren, die zur Verarbeitung in einem umfassenderen Kreis, der den Kreis beinhaltet, geeignet sind
 - **(c)** Spannungen in einem umfassenderen Kreis verarbeiten, um Einschränkungen des Kreises zu beseitigen
 
-Der Kreis muss den integrativen Wahlprozess anwenden, der in dieser Verfassung definiert ist, um eine\*n Kreis-Rep zu wählen, sofern eine Richtlinie keinen alternativen Prozess definiert. Nur die Kreismitglieder des Kreises sind für seine Kreis-Rep Rolle wählbar. Es darf nicht mehr als eine Person gleichzeitig als Kreis-Rep seines\*ihres Kreises dienen, sofern nicht eine Richtlinie eines ihn beinhaltenden Kreises dies erlaubt.
+Der Kreis muss den integrativen Wahlprozess anwenden, der in dieser Verfassung definiert ist, um einen Kreis-Rep zu wählen, sofern eine Richtlinie keinen alternativen Prozess definiert. Nur die Kreismitglieder des Kreises sind für seine Kreis-Rep Rolle wählbar. Es darf nicht mehr als eine Person gleichzeitig als Kreis-Rep seines Kreises dienen, sofern nicht eine Richtlinie eines ihn beinhaltenden Kreises dies erlaubt.
 
-Der\*Die gewählte Kreis-Rep wird ein Kreismitglied jedes Kreises, der diesen Kreis beinhaltet, mit der Befugnis, seinen\*ihren Kreis zu repräsentieren, genau wie ein Kreis-Lead. Ein ihn beinhaltender Kreis darf durch eine Richtlinie begrenzen oder verhindern, dass diese Kreis-Reps seine Kreismitglieder werden, doch nur falls seine Rollen einen anderen Weg haben, der eine vergleichbare Repräsentation innerhalb dieses Kreises gewährleistet.
+Der gewählte Kreis-Rep wird ein Kreismitglied jedes Kreises, der diesen Kreis beinhaltet, mit der Befugnis, seinen Kreis zu repräsentieren, genau wie ein Kreis-Lead. Ein ihn beinhaltender Kreis darf durch eine Richtlinie begrenzen oder verhindern, dass diese Kreis-Reps seine Kreismitglieder werden, doch nur falls seine Rollen einen anderen Weg haben, der eine vergleichbare Repräsentation innerhalb dieses Kreises gewährleistet.
 
 Ein Kreis darf Domänen oder Verantwortlichkeiten zu seiner eigenen Kreis-Rep Rolle hinzufügen, sowie diese Ergänzungen anpassen oder entfernen. Kein Kreis darf den Sinn und Zweck der Rolle anpassen oder entfernen, noch irgendwelche Verantwortlichkeiten, die für diese Rolle im Rahmen dieser Verfassung definiert wurden.
 
 
-#### 5.1.2 Prozessmoderator\*in und Kreis-Sekretär\*in
+#### 5.1.2 Prozessmoderator und Kreis-Sekretär
 
-Der\*Die Prozessmoderator\*in des Kreises ist dafür verantwortlich, dessen Governance Prozess zu moderieren. Der\*Die Kreis-Sekretär*in des Kreises ist dafür verantwortlich, die Ergebnisses seines Governance Prozesses zu erfassen und zu veröffentlichen, und hält eine Domäne über die Governance Aufzeichnungen des Kreises.
+Der Prozessmoderator des Kreises ist dafür verantwortlich, dessen Governance Prozess zu moderieren. Der Kreis-Sekretär des Kreises ist dafür verantwortlich, die Ergebnisses seines Governance Prozesses zu erfassen und zu veröffentlichen, und hält eine Domäne über die Governance Aufzeichnungen des Kreises.
 
-Jedes Kreismitglied eines Kreises darf jederzeit eine Wahl fordern, um jemanden als Prozessmoderator\*in oder Kreis-Sekretär\*in des Kreises zu wählen oder zu ersetzen. Der Kreis muss den hier definierten integrativen Wahlprozess anwenden, um eine\*n Prozessmoderator\*in und eine\*n Kreis-Sekretär\*in zu wählen. Keine Rolle oder Richtlinie darf diese Rollen zuweisen oder eine Zuweisung auf irgendeine andere Weise aufheben, noch diesen erforderlichen Prozess ändern. Normalerweise sind die einzigen wählbaren Kandidaten in diesen Wahlen die Mitglieder eines Kreises. Eine Richtlinie des Kreises oder irgendeines Super-Kreises darf jedoch wählbare Kandidaten hinzufügen oder einschränken.
+Jedes Kreismitglied eines Kreises darf jederzeit eine Wahl fordern, um jemanden als Prozessmoderator oder Kreis-Sekretär des Kreises zu wählen oder zu ersetzen. Der Kreis muss den hier definierten integrativen Wahlprozess anwenden, um einen Prozessmoderator und einen Kreis-Sekretär zu wählen. Keine Rolle oder Richtlinie darf diese Rollen zuweisen oder eine Zuweisung auf irgendeine andere Weise aufheben, noch diesen erforderlichen Prozess ändern. Normalerweise sind die einzigen wählbaren Kandidaten in diesen Wahlen die Mitglieder eines Kreises. Eine Richtlinie des Kreises oder irgendeines Super-Kreises darf jedoch wählbare Kandidaten hinzufügen oder einschränken.
 
 
 ### 5.2 Umfang von Governance
@@ -316,7 +316,7 @@ Keine anderen Entscheidungen sind gültige Ergebnisse des Governance Prozesses e
 Eine Richtlinie darf nur eines oder mehreres der folgenden Punkte sein:
 
 - **(a)** eine Einschränkung der Befugnis einer oder mehrerer der im Kreis enthaltenen Rollen; oder
-- **(b)** eine Gewährung einer Befugnis, die der Kreis oder der\*die Kreis-Lead gegenüber einer oder mehreren Rollen innehat; oder
+- **(b)** eine Gewährung einer Befugnis, die der Kreis oder der Kreis-Lead gegenüber einer oder mehreren Rollen innehat; oder
 - **(c)** eine Gewährung einer Befugnis, die es Personen oder Rollen, die andernfalls nicht befugt sind, erlaubt, eine der Domänen des Kreises zu kontrollieren oder auf sie einzuwirken, oder eine Einschränkung in Bezug darauf, wie sie das dürfen, falls sie anderweitig dazu befugt sind; oder
 - **(d)** eine Regel, die eine Standardregel oder einen Standardprozess in dieser Verfassung verändert, falls diese Veränderung explizit erlaubt ist.
 
@@ -325,30 +325,30 @@ Eine Richtlinie, die Befugnis gewährt oder einschränkt, gilt rekursiv auch in 
 
 ### 5.3 Die Governance verändern
 
-Jedes Kreismitglied eines Kreises darf seinen Governance Prozess initiieren, indem es eine Veränderung seiner Governance vorschlägt. Um das zu tun, muss der\*die ***„Vorschlagende“*** zuerst einen ***„Vorschlag“*** in schriftlicher Form mit allen anderen Kreismitgliedern teilen, indem er\*sie irgendeinen von dem\*der Kreis-Sekretär\*in zugelassenen Kommunikationskanal benutzt. Diese anderen Kreismitglieder dürfen dann Verständnisfragen stellen, Reaktionen geben und Bedenken hinsichtlich der Annahme des Vorschlags erheben. Jedes Bedenken ist ein ***„Einwand“***, sofern es die in dieser Verfassung genannten Kriterien erfüllt, und die Person, die es benannt hat, ist der\*die ***„Einwendende“***.
+Jedes Kreismitglied eines Kreises darf seinen Governance Prozess initiieren, indem es eine Veränderung seiner Governance vorschlägt. Um das zu tun, muss der ***„Vorschlagende“*** zuerst einen ***„Vorschlag“*** in schriftlicher Form mit allen anderen Kreismitgliedern teilen, indem er irgendeinen von dem Kreis-Sekretär zugelassenen Kommunikationskanal benutzt. Diese anderen Kreismitglieder dürfen dann Verständnisfragen stellen, Reaktionen geben und Bedenken hinsichtlich der Annahme des Vorschlags erheben. Jedes Bedenken ist ein ***„Einwand“***, sofern es die in dieser Verfassung genannten Kriterien erfüllt, und die Person, die es benannt hat, ist der ***„Einwender“***.
 
-Sobald jedes Kreismitglied bestätigt, dass es keine Einwände gegen einen Vorschlag hat, wird er angenommen und ändert die Governance des Kreises ab. Falls Einwände erhoben werden, müssen der\*die Vorschlagende und jede\*r Einwendende einen Weg finden, um die Einwände zu adressieren, bevor der Kreis den Vorschlag annimmt. Nach jedem solchen Versuch, muss allen Kreismitgliedern eine weitere Gelegenheit gegeben werden, um Einwände zu erheben. Ein Kreis darf eine Richtlinie erlassen, um eine Frist für das Erheben von Einwänden zu definieren, nach deren Ablauf von jedem Mitglied, das nicht geantwortet hat, angenommen wird, dass es keine Einwände hat. Während der Kreis einen Vorschlag asynchron verarbeitet, darf jedes Kreismitglied den*die Vorschlagende jederzeit auffordern, den Vorschlag stattdessen zur Verarbeitung in Echtzeit in ein Meeting zu bringen. Außer wenn eine Richtlinie etwas anderes besagt, hört die asynchrone Verarbeitung dann auf und der Vorschlag wird als zurückgezogen betrachtet, bis er in einem Meeting wieder vorgeschlagen wird.
+Sobald jedes Kreismitglied bestätigt, dass es keine Einwände gegen einen Vorschlag hat, wird er angenommen und ändert die Governance des Kreises ab. Falls Einwände erhoben werden, müssen der Vorschlagende und jeder Einwender einen Weg finden, um die Einwände zu adressieren, bevor der Kreis den Vorschlag annimmt. Nach jedem solchen Versuch, muss allen Kreismitgliedern eine weitere Gelegenheit gegeben werden, um Einwände zu erheben. Ein Kreis darf eine Richtlinie erlassen, um eine Frist für das Erheben von Einwänden zu definieren, nach deren Ablauf von jedem Mitglied, das nicht geantwortet hat, angenommen wird, dass es keine Einwände hat. Während der Kreis einen Vorschlag asynchron verarbeitet, darf jedes Kreismitglied den Vorschlagende jederzeit auffordern, den Vorschlag stattdessen zur Verarbeitung in Echtzeit in ein Meeting zu bringen. Außer wenn eine Richtlinie etwas anderes besagt, hört die asynchrone Verarbeitung dann auf und der Vorschlag wird als zurückgezogen betrachtet, bis er in einem Meeting wieder vorgeschlagen wird.
 
-Wenn ein Kreismitglied Vorschläge macht oder Einwände erhebt, darf es nur die Rollen im Kreis repräsentieren, die es entweder als Rollen-Lead ausübt oder als Kreis-Rep repräsentiert. Ein Kreismitglied darf zudem eine Rolle vertreten, für die es vorübergehend von einem\*r ihrer Rollen-Leads die Erlaubnis hat, solange bis diese abläuft oder zurückgezogen wird.
+Wenn ein Kreismitglied Vorschläge macht oder Einwände erhebt, darf es nur die Rollen im Kreis repräsentieren, die es entweder als Rollen-Lead ausübt oder als Kreis-Rep repräsentiert. Ein Kreismitglied darf zudem eine Rolle vertreten, für die es vorübergehend von einem ihrer Rollen-Leads die Erlaubnis hat, solange bis diese abläuft oder zurückgezogen wird.
 
 
 #### 5.3.1 Anforderungen an Vorschläge
 
-Damit ein Vorschlag gültig ist, muss der\*die Vorschlagende in der Lage sein:
+Damit ein Vorschlag gültig ist, muss der Vorschlagende in der Lage sein:
 
-- **(a)** eine Spannung zu beschreiben, die der Vorschlag für eine der Rollen des*der Vorschlagenden adressieren würde; und
+- **(a)** eine Spannung zu beschreiben, die der Vorschlag für eine der Rollen des Vorschlagenden adressieren würde; und
 - **(b)** ein Beispiel einer tatsächlichen, vergangenen oder aktuellen Situation zu schildern, welche diese Spannung illustriert; und
 - **(c)** eine begründete Erklärung darüber zu geben, wie der Vorschlag die Spannung in diesem Beispiel verringert hätte.
 
-Falls dem\*der Prozessmoderator\*in an irgendeinem Punkt klar wird, dass ein Vorschlag diesen Kriterien nicht gerecht wird, so muss der\*die Prozessmoderator\*in den Vorschlag verwerfen.
+Falls dem Prozessmoderator an irgendeinem Punkt klar wird, dass ein Vorschlag diesen Kriterien nicht gerecht wird, so muss der Prozessmoderator den Vorschlag verwerfen.
 
 
 #### 5.3.2 Anforderungen an Einwände
 
-Ein Bedenken hinsichtlich der Annahme eines Vorschlags zählt nur dann als ein Einwand, wenn der\*die Einwendende begründen kann, weshalb es **alle** der folgenden Kriterien erfüllt:
+Ein Bedenken hinsichtlich der Annahme eines Vorschlags zählt nur dann als ein Einwand, wenn der Einwender begründen kann, weshalb es **alle** der folgenden Kriterien erfüllt:
 
 - **(a)** Der Vorschlag würde die Fähigkeit des Kreises verringern, seinen Sinn und Zweck oder seine Verantwortlichkeiten auszudrücken.
-- **(b)** Der Vorschlag würde die Fähigkeit des\*der Einwendenden einschränken, den Sinn und Zweck oder eine Verantwortlichkeit einer Rolle zu erfüllen, die der\*die Einwendende im Kreis vertritt, selbst wenn der\*die Einwendende keine anderen Rollen in der Organisation ausüben würde.
+- **(b)** Der Vorschlag würde die Fähigkeit des Einwender einschränken, den Sinn und Zweck oder eine Verantwortlichkeit einer Rolle zu erfüllen, die der Einwender im Kreis vertritt, selbst wenn der Einwender keine anderen Rollen in der Organisation ausüben würde.
 - **(c)** Das Bedenken existiert nicht schon vorher, selbst in Abwesenheit des Vorschlags. Somit würde spezifisch durch die Annahme des Vorschlags eine neue Spannung erzeugt werden.
 - **(d)** Der Vorschlag würde die Wirkung zwangsläufig verursachen, oder, falls er die Wirkung verursachen könnte, hätte der Kreis keine angemessene Möglichkeit anzupassen, bevor bedeutender Schaden entstehen könnte.
 
@@ -357,49 +357,49 @@ Ein Bedenken gilt jedoch ungeachtet der obigen Kriterien immer als Einwand, fall
 
 #### 5.3.3 Mögliche Einwände testen
 
-Der\*Die Prozessmoderator\*in darf durch Fragen an den\*die Einwendende\*n testen, ob und wie das Bedenken die erforderlichen Kriterien für einen Einwand erfüllt. Bei der Bewertung der Antworten darf der\*die Prozessmoderator\*in nur beurteilen, ob die Argumente für jedes Kriterium logischer Schlussfolgerung entsprechen. Der\*Die Prozessmoderator\*in darf weder die Richtigkeit eines Arguments noch die Wichtigkeit, es zu adressieren, beurteilen.
+Der Prozessmoderator darf durch Fragen an den Einwender testen, ob und wie das Bedenken die erforderlichen Kriterien für einen Einwand erfüllt. Bei der Bewertung der Antworten darf der Prozessmoderator nur beurteilen, ob die Argumente für jedes Kriterium logischer Schlussfolgerung entsprechen. Der Prozessmoderator darf weder die Richtigkeit eines Arguments noch die Wichtigkeit, es zu adressieren, beurteilen.
 
-Wenn ein Einwand geltend gemacht wird, weil die Annahme des Vorschlags diese Verfassung verletzen würde, darf der\*die Prozessmoderator\*in den\*die Kreis-Sekretär\*in des Kreises bitten, auszulegen, ob das stimmt. Wenn der\*die Kreis-Sekretär\*in entscheidet, dass dies nicht der Fall ist, muss der\*die Prozessmoderator\*in den Einwand verwerfen.
+Wenn ein Einwand geltend gemacht wird, weil die Annahme des Vorschlags diese Verfassung verletzen würde, darf der Prozessmoderator den Kreis-Sekretär des Kreises bitten, auszulegen, ob das stimmt. Wenn der Kreis-Sekretär entscheidet, dass dies nicht der Fall ist, muss der Prozessmoderator den Einwand verwerfen.
 
 
 #### 5.3.4 Regeln der Integration
 
 Beim Versuch einen Einwand aufzulösen, gelten die folgenden Regeln:
 
-- **(a)** Der\*Die Prozessmoderator\*in muss einen Einwand testen, falls ein Kreismitglied dies anfragt. Wenn der Einwand die erforderlichen Kriterien nicht erfüllt, dann muss der\*die Prozessmoderator\*in ihn verwerfen.
-- **(b)** Der\*Die Einwendende muss versuchen, eine Anpassung des Vorschlags zu finden, die den Einwand auflöst und immer noch die Spannung des\*der Vorschlagenden adressiert. Falls der\*die Prozessmoderator\*in glaubt, dass der\*die Einwendende keinen ernstgemeinten Versuch unternimmt, dies zu tun, dann muss der\*die Prozessmoderator\*in den Einwand als aufgegeben betrachten und ihn fallen lassen.
-- **(c)** Jedes Kreismitglied darf dem\*der Vorschlagenden Verständnisfragen zur Spannung hinter dem Vorschlag stellen, oder zu Beispielen, die der\*die Vorschlagende zur Veranschaulichung der Spannung gebracht hat. Wenn der\*die Prozessmoderator\*in der Ansicht ist, dass der\*die Vorschlagende die Fragen nicht in gutem Glauben beantwortet, dann muss der\*die Prozessmoderator\*in den Vorschlag als fallengelassen betrachten.
-- **(d)** Der\*Die Einwendende darf einen veränderten Vorschlag machen, und begründen, weshalb dieser die Spannung lösen sollte. Auf Anfrage des\*der Einwendenden, muss der\*die Vorschlagende dann begründen, weshalb der angepasste Vorschlag nicht geeignet wäre, die Spannung in mindestens einem der vorgebrachten Beispiele zu lösen. Falls erforderlich, darf der\*die Vorschlagende mit weiteren Beispielen veranschaulichen, warum der angepasste Vorschlag die Spannung nicht lösen würde. Wenn der\*die Prozessmoderator\*in glaubt, dass der\*die Vorschlagende nicht in der Lage oder willens ist, dies zu tun, dann muss der\*die Prozessmoderator\*in den Vorschlag als fallengelassen betrachten.
+- **(a)** Der Prozessmoderator muss einen Einwand testen, falls ein Kreismitglied dies anfragt. Wenn der Einwand die erforderlichen Kriterien nicht erfüllt, dann muss der Prozessmoderator ihn verwerfen.
+- **(b)** Der Einwender muss versuchen, eine Anpassung des Vorschlags zu finden, die den Einwand auflöst und immer noch die Spannung des Vorschlagenden adressiert. Falls der Prozessmoderator glaubt, dass der Einwender keinen ernstgemeinten Versuch unternimmt, dies zu tun, dann muss der Prozessmoderator den Einwand als aufgegeben betrachten und ihn fallen lassen.
+- **(c)** Jedes Kreismitglied darf dem Vorschlagenden Verständnisfragen zur Spannung hinter dem Vorschlag stellen, oder zu Beispielen, die der Vorschlagende zur Veranschaulichung der Spannung gebracht hat. Wenn der Prozessmoderator der Ansicht ist, dass der Vorschlagende die Fragen nicht in gutem Glauben beantwortet, dann muss der Prozessmoderator den Vorschlag als fallengelassen betrachten.
+- **(d)** Der Einwender darf einen veränderten Vorschlag machen, und begründen, weshalb dieser die Spannung lösen sollte. Auf Anfrage des Einwender, muss der Vorschlagende dann begründen, weshalb der angepasste Vorschlag nicht geeignet wäre, die Spannung in mindestens einem der vorgebrachten Beispiele zu lösen. Falls erforderlich, darf der Vorschlagende mit weiteren Beispielen veranschaulichen, warum der angepasste Vorschlag die Spannung nicht lösen würde. Wenn der Prozessmoderator glaubt, dass der Vorschlagende nicht in der Lage oder willens ist, dies zu tun, dann muss der Prozessmoderator den Vorschlag als fallengelassen betrachten.
 
 
 #### 5.3.5 Integrativer Wahlprozess
 
-Jedes Kreismitglied darf den Governance Prozess des Kreises auch anstoßen, indem es eine Wahl für eine\*n Kreis-Rep, Prozessmoderator\*in oder Kreis-Sekretär\*in einberuft. Der\*Die amtierende Prozessmoderator\*in muss dann den folgenden ***„Integrativen Wahlprozess“*** durchführen:
+Jedes Kreismitglied darf den Governance Prozess des Kreises auch anstoßen, indem es eine Wahl für einen Kreis-Rep, Prozessmoderator oder Kreis-Sekretär einberuft. Der amtierende Prozessmoderator muss dann den folgenden ***„Integrativen Wahlprozess“*** durchführen:
 
-- **(a) Beschreibe die Rolle**: Zuerst identifiziert der\*die Prozessmoderator\*in die zu wählende Rolle und sucht eine Amtsdauer für die Wahl aus. Der\*Die Prozessmoderator\*in darf auch andere für die Wahl relevante Informationen vorstellen. Während dieses und des nächsten Schrittes darf niemand Kommentare zu potentiellen Kandidat\*innen abgeben.
-- **(b) Nominiere Kandidat\*innen**: Jedes Kreismitglied verwendet einen Wahlzettel oder ein anderes vertrauliches Medium, um den\*die wählbaren Kandidat\*in zu nominieren, von dem das Kreismitglied glaubt, dass er\*sie am besten zur Rolle passt. Kreismitglieder müssen ihren Wahlzettel zudem mit ihrem eigenen Namen kennzeichnen. Niemand darf sich der Wahl enthalten oder mehrere Leute nominieren.
-- **(c) Nominierungsrunde**: Während dieses Schrittes teilt der\*die Prozessmoderator\*in jede Nominierung mit allen Kreismitgliedern. Für jede einzelne erklärt der\*die Nominierende, warum er\*sie glaubt, dass sein\*ihre Nominierte\*r gut für die Rolle passen würde. Niemand sonst reagiert. Der\*Die Nominierende darf keine Kommentare zu anderen potentiellen Kandidat\*innen außer seinem\*r Nominierten abgeben.
+- **(a) Beschreibe die Rolle**: Zuerst identifiziert der Prozessmoderator die zu wählende Rolle und sucht eine Amtsdauer für die Wahl aus. Der Prozessmoderator darf auch andere für die Wahl relevante Informationen vorstellen. Während dieses und des nächsten Schrittes darf niemand Kommentare zu potentiellen Kandidaten abgeben.
+- **(b) Nominiere Kandidaten**: Jedes Kreismitglied verwendet einen Wahlzettel oder ein anderes vertrauliches Medium, um den wählbaren Kandidat zu nominieren, von dem das Kreismitglied glaubt, dass er am besten zur Rolle passt. Kreismitglieder müssen ihren Wahlzettel zudem mit ihrem eigenen Namen kennzeichnen. Niemand darf sich der Wahl enthalten oder mehrere Leute nominieren.
+- **(c) Nominierungsrunde**: Während dieses Schrittes teilt der Prozessmoderator jede Nominierung mit allen Kreismitgliedern. Für jede einzelne erklärt der Nominierende, warum er glaubt, dass sein Nominierter gut für die Rolle passen würde. Niemand sonst reagiert. Der Nominierende darf keine Kommentare zu anderen potentiellen Kandidaten außer seinem Nominierten abgeben.
 - **(d) Nominierungsänderungsrunde**: Sobald alle Nominierungen geteilt worden sind, darf jedes Kreismitglied seine Nominierung ändern und den Grund für die Änderung erklären. Es sind keine Reaktionen erlaubt.
-- **(e) Einen Vorschlag machen**: Der\*Die Prozessmoderator\*in zählt die Nominierungen und macht einen Vorschlag zur Wahl des\*der Kandidat\*in mit den meisten Nominierungen. Falls es eine Stimmengleichheit gibt, dann hat der\*die Prozessmoderator\*in die Wahl eines der folgenden Dinge tun:
-(i) falls nur einer der stimmengleichen Kandidat\*innen sich selbst nominiert hat, diese Person vorschlagen; oder
-(ii) falls die Person, die die Rolle aktuell ausübt, unter den stimmengleichen Kandidat\*innen ist, diese Person vorschlagen; oder (iii) blind eine\*n der stimmengleichen Kandidat\*innen auslosen und diese Person vorschlagen; oder
-(iv) zurückgehen zum vorigen Schritt und jedes Kreismitglied, welches jemanden anderes als eine\*n stimmengleiche\*n Kandidat\*in gewählt hat, dazu auffordern, diese Nominierung zu einem\*r der stimmengleichen Kandidat\*innen zu ändern.
-- **(f) Einwandrunde**: Der\*Die Prozessmoderator\*in fragt jedes Kreismitglied, ob es irgendwelche Einwände gegen den Vorschlag sieht. Falls irgendwelche Einwände auftreten, darf der\*die Prozessmoderator\*in entweder eine Diskussion erlauben, um zu versuchen, diese zu lösen, oder den Vorschlag verwerfen. Falls er verworfen wird, muss der\*die Prozessmoderator\*in dann zu dem vorherigen Schritt in diesem Prozess zurückgehen, alle Nominierungen für den\*die verworfene\*n Kandidat\*in ignorieren, und die Regeln des vorherigen Schrittes anwenden, um stattdessen eine\*n andere\*n Kandidat\*in zum Vorschlagen auszuwählen.
+- **(e) Einen Vorschlag machen**: Der Prozessmoderator zählt die Nominierungen und macht einen Vorschlag zur Wahl des Kandidat mit den meisten Nominierungen. Falls es eine Stimmengleichheit gibt, dann hat der Prozessmoderator die Wahl eines der folgenden Dinge tun:
+(i) falls nur einer der stimmengleichen Kandidaten sich selbst nominiert hat, diese Person vorschlagen; oder
+(ii) falls die Person, die die Rolle aktuell ausübt, unter den stimmengleichen Kandidaten ist, diese Person vorschlagen; oder (iii) blind einen der stimmengleichen Kandidaten auslosen und diese Person vorschlagen; oder
+(iv) zurückgehen zum vorigen Schritt und jedes Kreismitglied, welches jemanden anderes als einen timmengleichen Kandidat gewählt hat, dazu auffordern, diese Nominierung zu einem der stimmengleichen Kandidaten zu ändern.
+- **(f) Einwandrunde**: Der Prozessmoderator fragt jedes Kreismitglied, ob es irgendwelche Einwände gegen den Vorschlag sieht. Falls irgendwelche Einwände auftreten, darf der Prozessmoderator entweder eine Diskussion erlauben, um zu versuchen, diese zu lösen, oder den Vorschlag verwerfen. Falls er verworfen wird, muss der Prozessmoderator dann zu dem vorherigen Schritt in diesem Prozess zurückgehen, alle Nominierungen für den verworfenen Kandidat ignorieren, und die Regeln des vorherigen Schrittes anwenden, um stattdessen einen anderen Kandidaten zum Vorschlagen auszuwählen.
 
-Ein Kreis darf eine Richtlinie erlassen, um eine Frist für die Nominierung eines\*r Kandidat\*in oder für die Antwort auf einen Vorschlag während des Integrativen Wahlprozesses zu definieren. Nach Ablauf dieser Frist muss der\*die Prozessmoderator\*in jede\*n, der\*die nicht geantwortet hat, für den Rest des Prozesses ausschließen.
+Ein Kreis darf eine Richtlinie erlassen, um eine Frist für die Nominierung eines Kandidat oder für die Antwort auf einen Vorschlag während des Integrativen Wahlprozesses zu definieren. Nach Ablauf dieser Frist muss der Prozessmoderator jeden, der nicht geantwortet hat, für den Rest des Prozesses ausschließen.
 
-Der\*Die Prozessmoderator\*in eines Kreises ist dafür zuständig, nach Ablauf jeder Amtsdauer Neuwahlen für die gewählten Rollen des Kreises anzusetzen.
+Der Prozessmoderator eines Kreises ist dafür zuständig, nach Ablauf jeder Amtsdauer Neuwahlen für die gewählten Rollen des Kreises anzusetzen.
 
 
-#### 5.3.6 Ersatz für Prozessmoderator\*in und Kreis-Sekretär\*in
+#### 5.3.6 Ersatz für Prozessmoderator und Kreis-Sekretär
 
-Eine Ersatzperson darf als Prozessmoderator\*in oder Kreis-Sekretär\*in agieren, solange die Rolle unbesetzt ist. Wenn der\*die reguläre Prozessmoderator\*in oder Kreis-Sekretär\*in abwesend ist, oder aus irgendeinem Grund um einen Ersatz bittet, darf auch eine Vertretung einspringen.
+Eine Ersatzperson darf als Prozessmoderator oder Kreis-Sekretär agieren, solange die Rolle unbesetzt ist. Wenn der reguläre Prozessmoderator oder Kreis-Sekretär abwesend ist, oder aus irgendeinem Grund um einen Ersatz bittet, darf auch eine Vertretung einspringen.
 
 Wann immer Ersatz benötigt wird, gilt zur Ermittlung der Vertretung die folgende Rangfolge:
 
-- **(a)** jemand, der\*die von der zu vertretenden Person benannt wurde; oder
-- **(b)** für den\*die Prozessmoderator\*in, der\*die amtierende Kreis-Sekretär\*in des Kreises, und für den\*die Kreis-Sekretär\*in, der\*die amtierende Prozessmoderator\*in des Kreises;
-- **(c)** der\*die Kreis-Lead des Kreises, oder, falls es mehrere Kreis-Leads gibt, der\*die erste, der\*die erklärt, dass er*sie als Vertretung einspringt; oder
+- **(a)** jemand, der von der zu vertretenden Person benannt wurde; oder
+- **(b)** für den Prozessmoderator, der amtierende Kreis-Sekretär des Kreises, und für den Kreis-Sekretär, der amtierende Prozessmoderator des Kreises;
+- **(c)** der Kreis-Lead des Kreises, oder, falls es mehrere Kreis-Leads gibt, der erste, der erklärt, dass er als Vertretung einspringt; oder
 - **(d)** das erste Kreismitglied, das erklärt, dass es als Vertretung einspringt.
 
 
@@ -407,82 +407,82 @@ Wann immer Ersatz benötigt wird, gilt zur Ermittlung der Vertretung die folgend
 
 Zusätzlich zur asynchronen Verarbeitung von Vorschlägen außerhalb von Meetings, hält jeder Kreis auch regelmäßige ***„Governance Meetings“*** ab, um den Governance Prozess des Kreises in Echtzeit durchzuführen.
 
-Der\*Die Kreis-Sekretär\*in eines Kreises ist dafür zuständig, dessen Governance Meetings anzusetzen. Zusätzlich zu allen regulär angesetzten Governance Meetings des Kreises muss der\*die Kreis-Sekretär\*in auf Anfrage eines Kreismitglieds unverzüglich außerordentliche Governance Meetings ansetzen. Das anfragende Mitglied darf sein Ziel für ein außerordentliches Governance Meeting nennen und auch eingrenzen, was im Meeting verändert werden darf. Unter anderem darf das Meeting darauf eingegrenzt werden, nur eine spezifische Spannung zu bearbeiten, oder nur bestimmte Rollen zu modifizieren. In diesem Fall ist die Befugnis dieses speziellen Governance Meetings darauf begrenzt, nur Vorschläge für das angegebene Ziel zu verarbeiten, und Veränderungen nur innerhalb der angegebenen Begrenzungen vorzunehmen.
+Der Kreis-Sekretär eines Kreises ist dafür zuständig, dessen Governance Meetings anzusetzen. Zusätzlich zu allen regulär angesetzten Governance Meetings des Kreises muss der Kreis-Sekretär auf Anfrage eines Kreismitglieds unverzüglich außerordentliche Governance Meetings ansetzen. Das anfragende Mitglied darf sein Ziel für ein außerordentliches Governance Meeting nennen und auch eingrenzen, was im Meeting verändert werden darf. Unter anderem darf das Meeting darauf eingegrenzt werden, nur eine spezifische Spannung zu bearbeiten, oder nur bestimmte Rollen zu modifizieren. In diesem Fall ist die Befugnis dieses speziellen Governance Meetings darauf begrenzt, nur Vorschläge für das angegebene Ziel zu verarbeiten, und Veränderungen nur innerhalb der angegebenen Begrenzungen vorzunehmen.
 
 
 #### 5.4.1 Teilnahme
 
-Alle Kreismitglieder eines Kreises dürfen an seinen Governance Meetings teilnehmen. Wer als Prozessmoderator\*in und Kreis-Sekretär\*in dient, darf ebenfalls teilnehmen, auch ohne Kreismitglied des Kreises zu sein. In diesem Fall wird die Person temporäres Kreismitglied für die Dauer des Meetings.
+Alle Kreismitglieder eines Kreises dürfen an seinen Governance Meetings teilnehmen. Wer als Prozessmoderator und Kreis-Sekretär dient, darf ebenfalls teilnehmen, auch ohne Kreismitglied des Kreises zu sein. In diesem Fall wird die Person temporäres Kreismitglied für die Dauer des Meetings.
 
-Als Kreis-Rep für einen Kreis darfst du jede\*n Partner\*in einladen, einem Governance Meeting eines Kreises beizuwohnen, der deinen Kreis unmittelbar enthält. Du darfst diese Einladung nur gegenüber einem\*r Partner\*in auf einmal aussprechen, und lediglich um dabei zu helfen, eine spezifische Spannung zu verarbeiten, die den von dir repräsentierten Kreis betrifft. Du musst diese Spannung selbst auch empfinden und glauben, dass es Sinn macht, sie im Kreis zu verarbeiten. Dein eingeladener Gast wird ein temporäres Kreismitglied für die Dauer des Meetings, oder bis du die Einladung zurücknimmst. Dein Gast darf im Meeting zusammen mit dir deinen Kreis vertreten, jedoch nur während der Verarbeitung dieser spezifischen Spannung.
+Als Kreis-Rep für einen Kreis darfst du jeden Partner einladen, einem Governance Meeting eines Kreises beizuwohnen, der deinen Kreis unmittelbar enthält. Du darfst diese Einladung nur gegenüber einem Partner auf einmal aussprechen, und lediglich um dabei zu helfen, eine spezifische Spannung zu verarbeiten, die den von dir repräsentierten Kreis betrifft. Du musst diese Spannung selbst auch empfinden und glauben, dass es Sinn macht, sie im Kreis zu verarbeiten. Dein eingeladener Gast wird ein temporäres Kreismitglied für die Dauer des Meetings, oder bis du die Einladung zurücknimmst. Dein Gast darf im Meeting zusammen mit dir deinen Kreis vertreten, jedoch nur während der Verarbeitung dieser spezifischen Spannung.
 
 Abgesehen von den oben Genannten darf niemand sonst an den Governance Meetings eines Kreises teilnehmen.
 
 #### 5.4.2 Ankündigung und Dauer
 
-Ein Kreis darf ein Governance Meeting nur dann durchführen, wenn der\*die Kreis-Sekretär*in das Meeting mit angemessenem Vorlauf allen Kreismitgliedern angekündigt hat. Darüber hinaus ist zur Durchführung eines Governance Meetings in einem Kreis keine Mindestanzahl von Teilnehmenden erforderlich, sofern eine Richtlinie nicht eine solche definiert.
+Ein Kreis darf ein Governance Meeting nur dann durchführen, wenn der Kreis-Sekretär das Meeting mit angemessenem Vorlauf allen Kreismitgliedern angekündigt hat. Darüber hinaus ist zur Durchführung eines Governance Meetings in einem Kreis keine Mindestanzahl von Teilnehmer erforderlich, sofern eine Richtlinie nicht eine solche definiert.
 
-Governance Meetings enden, sobald sie die ursprünglich von dem\*der Kreis-Sekretär\*in geplante Dauer erreicht haben. Der\*Die Kreis-Sekretär\*in darf während des Meetings entscheiden, es zu verlängern, doch nur wenn sich kein Kreismitglied dagegen ausspricht.
+Governance Meetings enden, sobald sie die ursprünglich von dem Kreis-Sekretär geplante Dauer erreicht haben. Der Kreis-Sekretär darf während des Meetings entscheiden, es zu verlängern, doch nur wenn sich kein Kreismitglied dagegen ausspricht.
 
 Jedes Kreismitglied, das ein Governance-Meeting ganz oder teilweise versäumt, zählt als Mitglied, das die Möglichkeit hatte, Bedenken in Bezug auf jeden darin unterbreiteten Vorschlag vorzubringen. Daher darf ein Kreis in einem Governance Meeting Vorschläge ohne Rücksicht auf abwesende Mitglieder annehmen.
 
 
 #### 5.4.3 Meeting Prozess
 
-Der\*Die Prozessmoderator\*in muss für Governance Meetings den folgenden Prozess verwenden:
+Der Prozessmoderator muss für Governance Meetings den folgenden Prozess verwenden:
 
-- **(a) Check-in Runde**: Alle Teilnehmenden äußern der Reihe nach ihr aktuelles Befinden, oder teilen einen anderen Wortbeitrag zur Eröffnung des Meetings. Reaktionen sind nicht erlaubt.
-- **(b) Agenda-Erstellung & Verarbeitung**: Der\*Die Prozessmoderator\*in erstellt eine Agenda aus zu verarbeitenden Spannungen und verarbeitet dann einen Agendapunkt nach dem anderen.
-- **(c) Abschlussrunde**: Alle Teilnehmenden teilen der Reihe nach ihre Abschlussreflektion über das Meeting. Reaktionen sind nicht erlaubt.
+- **(a) Check-in Runde**: Alle Teilnehmer äußern der Reihe nach ihr aktuelles Befinden, oder teilen einen anderen Wortbeitrag zur Eröffnung des Meetings. Reaktionen sind nicht erlaubt.
+- **(b) Agenda-Erstellung & Verarbeitung**: Der Prozessmoderator erstellt eine Agenda aus zu verarbeitenden Spannungen und verarbeitet dann einen Agendapunkt nach dem anderen.
+- **(c) Abschlussrunde**: Alle Teilnehmer teilen der Reihe nach ihre Abschlussreflektion über das Meeting. Reaktionen sind nicht erlaubt.
 
-Ein\*e Teilnehmer\*in darf während dieses Prozesses jederzeit um eine ***„Auszeit“*** [Time Out] Pause bitten. Der\*Die Prozessmoderator\*in darf entscheiden, ob er\*sie diese Bitte gewährt oder ablehnt. Während der Auszeit dürfen die Teilnehmer\*innen administrative Themen oder die Regeln dieser Verfassung diskutieren. Sie dürfen die Auszeit nicht nutzen, um auf die Klärung einer Spannung, eines Vorschlags oder eines Einwands hinzuarbeiten. Der\*Die Prozessmoderator\*in darf die Auszeit jederzeit beenden, und den normalen Meeting Prozess wieder aufnehmen.
+Ein Teilnehmer darf während dieses Prozesses jederzeit um eine ***„Auszeit“*** [Time Out] Pause bitten. Der Prozessmoderator darf entscheiden, ob er diese Bitte gewährt oder ablehnt. Während der Auszeit dürfen die Teilnehmer administrative Themen oder die Regeln dieser Verfassung diskutieren. Sie dürfen die Auszeit nicht nutzen, um auf die Klärung einer Spannung, eines Vorschlags oder eines Einwands hinzuarbeiten. Der Prozessmoderator darf die Auszeit jederzeit beenden, und den normalen Meeting Prozess wieder aufnehmen.
 
 Eine Richtlinie darf diesen Prozess ergänzen, darf jedoch nicht im Widerspruch zu irgendeiner Regel oder Anforderung stehen, die in diesem Artikel definiert ist.
 
 
 #### 5.4.4 Agenda-Erstellung
 
-Der\*Die Prozessmoderator\*in erstellt eine Agenda der Spannungen, indem er\*sie alle Teilnehmenden um Agendapunkte bittet. Der\*Die Prozessmoderator\*in muss dies innerhalb des Meetings tun und nicht davor. Jede\*r Teilnehmende darf so viele Agendapunkte hinzufügen, wie gewünscht, indem er*sie einen kurzen Platzhalter für jeden Punkt nennt, wobei hier noch keine Erklärung oder Diskussion erlaubt ist. Die Teilnehmenden dürfen während des Meetings, zwischen der Verarbeitung jeglicher existierender Agendapunkte, weitere Agendapunkte hinzufügen.
+Der Prozessmoderator erstellt eine Agenda der Spannungen, indem er alle Teilnehmer um Agendapunkte bittet. Der Prozessmoderator muss dies innerhalb des Meetings tun und nicht davor. Jeder Teilnehmer darf so viele Agendapunkte hinzufügen, wie gewünscht, indem er einen kurzen Platzhalter für jeden Punkt nennt, wobei hier noch keine Erklärung oder Diskussion erlaubt ist. Die Teilnehmer dürfen während des Meetings, zwischen der Verarbeitung jeglicher existierender Agendapunkte, weitere Agendapunkte hinzufügen.
 
-Für ein reguläres Governance Meeting darf der\*die Prozessmoderator\*in die Reihenfolge bestimmen, in welcher die Agendapunkte verarbeitet werden. Auf Verlangen eines\*r Meetingteilnehmers\*in muss jedoch jeder Agendapunkt, der eine Wahl erfordert, vor allen anderen behandelt werden. Für ein spezielles Governance Meeting, das auf Verlangen eines\*r Teilnehmenden angesetzt wurde, darf diese\*r Teilnehmer*in die Reihenfolge der Agendapunkte bestimmen.
+Für ein reguläres Governance Meeting darf der Prozessmoderator die Reihenfolge bestimmen, in welcher die Agendapunkte verarbeitet werden. Auf Verlangen eines Meetingteilnehmers muss jedoch jeder Agendapunkt, der eine Wahl erfordert, vor allen anderen behandelt werden. Für ein spezielles Governance Meeting, das auf Verlangen eines Teilnehmer angesetzt wurde, darf dieser Teilnehmer die Reihenfolge der Agendapunkte bestimmen.
 
-Agendapunkte werden einer nach dem anderen verarbeitet. Um eine Anfrage für eine Wahl zu verarbeiten, verwendet der\*die Prozessmoderator\*in den integrativen Wahlprozess. Um alles andere zu verarbeiten, benutzt der\*die Prozessmoderator\*in den unten definierten Prozess der integrativen Entscheidungsfindung.
+Agendapunkte werden einer nach dem anderen verarbeitet. Um eine Anfrage für eine Wahl zu verarbeiten, verwendet der Prozessmoderator den integrativen Wahlprozess. Um alles andere zu verarbeiten, benutzt der Prozessmoderator den unten definierten Prozess der integrativen Entscheidungsfindung.
 
 
 #### 5.4.5 Prozess der integrativen Entscheidungsfindung
 
-Der\*Die Prozessmoderator\*in muss den ***„Prozess der integrativen Entscheidungsfindung“*** wie folgt durchführen:
+Der Prozessmoderator muss den ***„Prozess der integrativen Entscheidungsfindung“*** wie folgt durchführen:
 
-- **(a) Vorschlag vorstellen**: Zuerst darf der\*die Vorschlagende die Spannung beschreiben und einen Vorschlag vorstellen, um sie zu lösen. Auf Bitte des\*der Vorschlagenden darf der\*die Prozessmoderator\*in anderen erlauben, bei der Erstellung eines Vorschlags zu helfen. Der\*Die Prozessmoderator\*in muss diese Hilfe jedoch ausschließlich darauf fokussieren, zu einem initialen Vorschlag zu gelangen, um die Spannung des\*der Vorschlagenden zu lösen. Der\*Die Prozessmoderator\*in muss die Diskussion anderer Spannungen oder Bedenken in Bezug auf den Vorschlag unterbinden.
-- **(b) Verständnisfragen**: Sobald der\*die Vorschlagende einen Vorschlag gemacht hat, dürfen andere Fragen stellen, um den Vorschlag oder die Spannung dahinter besser zu verstehen. Der\*Die Vorschlagende darf jede Frage beantworten oder die Beantwortung verweigern. Der\*Die Prozessmoderator\*in muss alle Reaktionen oder Meinungen, die in Bezug auf den Vorschlag geäußert werden, stoppen und Diskussionen jeder Art unterbinden. Zudem dürfen die Teilnehmenden während dieses Schrittes, oder zu jedem anderen Zeitpunkt, zu dem Teilnehmende sprechen dürfen, den\*die Kreis-Sekretär\*in auffordern, den Vorschlag vorzulesen oder jegliche bestehende Governance zu zeigen, und er*sie muss der Bitte nachkommen.
-- **(c) Reaktionsrunde**: Danach darf jede\*r Teilnehmende, mit Ausnahme des\*der Vorschlagenden, nacheinander Reaktionen auf den Vorschlag teilen. Der\*Die Prozessmoderator\*in muss jegliche Kommentare außer der Reihe, jegliche Versuche, andere in einen Dialog zu verwickeln, sowie jegliche Reaktionen auf andere Reaktionen statt auf den Vorschlag, unmittelbar stoppen.
-- **(d) Gelegenheit zur Klärung**: Als nächstes darf der\*die Vorschlagende als Antwort die Reaktionen kommentieren und Verbesserungen am Vorschlag vornehmen. Die primäre Absicht jeglicher Verbesserungen muss jedoch sein, die Spannung des\*der Vorschlagenden besser zu lösen, und nicht die Spannungen, die von anderen erhoben wurden. Der\*Die Prozessmoderator\*in muss Kommentare von jedem anderen außer dem\*der Vorschlagenden oder dem\*der Kreis-Sekretär\*in unmittelbar stoppen. Alle Handlungen des\*der Kreis-Sekretär*in müssen sich auf das Erfassen des geänderten Vorschlags beschränken.
-- **(e) Einwandrunde**: Danach darf jede\*r Teilnehmende, eine\*r nacheinander, Bedenken gegen die Annahme des Vorschlag erheben. Der\*Die Prozessmoderator\*in muss diese Bedenken entweder als Einwände festhalten, oder sie testen, um zu sehen, ob sie den Einwandskriterien genügen und alle festhalten, die es tun. Falls es keine Einwände gibt, dann ist der Vorschlag angenommen. Während der\*die Prozessmoderator\*in Bedenken testet und Einwände erfasst, muss er\*sie Diskussionen oder Antworten jeder Art von anderen außer dem*der Einwendenden stoppen und abweisen.
-- **(f) Integration**: Falls es Einwände gibt, fokussiert der\*die Prozessmoderator\*in auf jeden einzelnen nacheinander. Für jeden brainstormen die Teilnehmenden, um eine potentielle Verbesserung zu finden, die den Einwand auflöst. Der\*Die Prozessmoderator\*in kennzeichnet einen Einwand als gelöst, sobald der\*die Einwendende bestätigt, dass der verbesserte Vorschlag den Einwand nicht hervorrufen würde, und der\*die Vorschlagende bestätigt, dass er immer noch die Spannung löst. Während dieses Schrittes muss der\*die Prozessmoderator\*in die Regeln der Integration anwenden, die in diesem Artikel beschrieben sind. Sobald alle Einwände gelöst sind, geht der\*die Prozessmoderator\*in mit dem angepassten Vorschlag zurück zur Einwandrunde.
+- **(a) Vorschlag vorstellen**: Zuerst darf der Vorschlagende die Spannung beschreiben und einen Vorschlag vorstellen, um sie zu lösen. Auf Bitte des Vorschlagenden darf der Prozessmoderator anderen erlauben, bei der Erstellung eines Vorschlags zu helfen. Der Prozessmoderator muss diese Hilfe jedoch ausschließlich darauf fokussieren, zu einem initialen Vorschlag zu gelangen, um die Spannung des Vorschlagenden zu lösen. Der Prozessmoderator muss die Diskussion anderer Spannungen oder Bedenken in Bezug auf den Vorschlag unterbinden.
+- **(b) Verständnisfragen**: Sobald der Vorschlagende einen Vorschlag gemacht hat, dürfen andere Fragen stellen, um den Vorschlag oder die Spannung dahinter besser zu verstehen. Der Vorschlagende darf jede Frage beantworten oder die Beantwortung verweigern. Der Prozessmoderator muss alle Reaktionen oder Meinungen, die in Bezug auf den Vorschlag geäußert werden, stoppen und Diskussionen jeder Art unterbinden. Zudem dürfen die Teilnehmer während dieses Schrittes, oder zu jedem anderen Zeitpunkt, zu dem Teilnehmer sprechen dürfen, den Kreis-Sekretär auffordern, den Vorschlag vorzulesen oder jegliche bestehende Governance zu zeigen, und er muss der Bitte nachkommen.
+- **(c) Reaktionsrunde**: Danach darf jeder Teilnehmer, mit Ausnahme des Vorschlagenden, nacheinander Reaktionen auf den Vorschlag teilen. Der Prozessmoderator muss jegliche Kommentare außer der Reihe, jegliche Versuche, andere in einen Dialog zu verwickeln, sowie jegliche Reaktionen auf andere Reaktionen statt auf den Vorschlag, unmittelbar stoppen.
+- **(d) Gelegenheit zur Klärung**: Als nächstes darf der Vorschlagende als Antwort die Reaktionen kommentieren und Verbesserungen am Vorschlag vornehmen. Die primäre Absicht jeglicher Verbesserungen muss jedoch sein, die Spannung des Vorschlagenden besser zu lösen, und nicht die Spannungen, die von anderen erhoben wurden. Der Prozessmoderator muss Kommentare von jedem anderen außer dem Vorschlagenden oder dem Kreis-Sekretär unmittelbar stoppen. Alle Handlungen des Kreis-Sekretär müssen sich auf das Erfassen des geänderten Vorschlags beschränken.
+- **(e) Einwandrunde**: Danach darf jeder Teilnehmer, einer nacheinander, Bedenken gegen die Annahme des Vorschlag erheben. Der Prozessmoderator muss diese Bedenken entweder als Einwände festhalten, oder sie testen, um zu sehen, ob sie den Einwandskriterien genügen und alle festhalten, die es tun. Falls es keine Einwände gibt, dann ist der Vorschlag angenommen. Während der Prozessmoderator Bedenken testet und Einwände erfasst, muss er Diskussionen oder Antworten jeder Art von anderen außer dem Einwender stoppen und abweisen.
+- **(f) Integration**: Falls es Einwände gibt, fokussiert der Prozessmoderator auf jeden einzelnen nacheinander. Für jeden brainstormen die Teilnehmer, um eine potentielle Verbesserung zu finden, die den Einwand auflöst. Der Prozessmoderator kennzeichnet einen Einwand als gelöst, sobald der Einwender bestätigt, dass der verbesserte Vorschlag den Einwand nicht hervorrufen würde, und der Vorschlagende bestätigt, dass er immer noch die Spannung löst. Während dieses Schrittes muss der Prozessmoderator die Regeln der Integration anwenden, die in diesem Artikel beschrieben sind. Sobald alle Einwände gelöst sind, geht der Prozessmoderator mit dem angepassten Vorschlag zurück zur Einwandrunde.
 
 
 ### 5.5 Prozessversagen
 
-Ein ***„Prozessversagen“*** liegt vor, wenn ein Kreis ein Verhaltensmuster oder ein Ergebnis aufweist, das die Regeln dieser Verfassung verletzt. Der\*Die Prozessmoderator\*in oder der\*die Kreis-Sekretär\*in eines Kreises dürfen mittels ihres vernünftigen Urteilsvermögens ein Prozessversagen in ihrem Kreis oder in jeglichem Sub-Kreis erklären. Jede\*r betroffene Partner\*in, darf ferner von einem\*r Prozessmoderator\*in fordern, einen Sub-Kreis auf ein potenzielles Prozessversagen zu prüfen, und der\*die Prozessmoderator\*in ist dafür verantwortlich, auf Anfrage die Meetings und Aufzeichnungen eines Sub-Kreises zu prüfen und ein Prozessversagen zu erklären, falls ein solches entdeckt wird.
+Ein ***„Prozessversagen“*** liegt vor, wenn ein Kreis ein Verhaltensmuster oder ein Ergebnis aufweist, das die Regeln dieser Verfassung verletzt. Der Prozessmoderator oder der Kreis-Sekretär eines Kreises dürfen mittels ihres vernünftigen Urteilsvermögens ein Prozessversagen in ihrem Kreis oder in jeglichem Sub-Kreis erklären. Jeder betroffene Partner, darf ferner von einem Prozessmoderator fordern, einen Sub-Kreis auf ein potenzielles Prozessversagen zu prüfen, und der Prozessmoderator ist dafür verantwortlich, auf Anfrage die Meetings und Aufzeichnungen eines Sub-Kreises zu prüfen und ein Prozessversagen zu erklären, falls ein solches entdeckt wird.
 
 
 #### 5.5.1 Versagen aufgrund gescheiterter Governance
 
-Der\*Die Prozessmoderator\*in eines Kreises darf außerdem ein Prozessversagen im Kreis erklären, falls ein Vorschlag nicht zu einer Lösung kommt, nachdem die Beteiligten angemessen Zeit und Mühe darauf verwendet haben, eine Lösung zu suchen.
+Der Prozessmoderator eines Kreises darf außerdem ein Prozessversagen im Kreis erklären, falls ein Vorschlag nicht zu einer Lösung kommt, nachdem die Beteiligten angemessen Zeit und Mühe darauf verwendet haben, eine Lösung zu suchen.
 
 
 #### 5.5.2 Prozesswiederherstellung
 
 Wann immer eine befugte Partei ein Prozessversagen in einem Kreis erklärt, geschieht das Folgende:
 
-- **(a)** der\*die Prozessmoderator\*in erhält die Befugnis, Logik und Relevanz aller Argumente zu beurteilen, die gemacht wurden, um Vorschläge oder Einwände im Kreis geltend zu machen; und
-- **(b)** der\*die Prozessmoderator\*in des Super-Kreises erhält ein Projekt, das ordentliche Verfahren im Kreis wiederherzustellen; und
-- **(c)** der\*die Prozessmoderator\*in des Super-Kreises erhält die Befugnis, als Prozessmoderator\*in oder Kreis-Sekretär\*in des Kreises zu übernehmen; und
-- **(d)** der\*die Prozessmoderator\*in des Super-Kreises darf für die Dauer des Prozessversagens eine\*n zusätzliche\*n Kreis-Lead zuweisen. Alle Entscheidungen, die diese Person als Kreis-Lead trifft, übertrumpfen und verhindern alle widersprechenden Entscheidungen eines\*r anderen Kreis-Lead\*s.
+- **(a)** der Prozessmoderator erhält die Befugnis, Logik und Relevanz aller Argumente zu beurteilen, die gemacht wurden, um Vorschläge oder Einwände im Kreis geltend zu machen; und
+- **(b)** der Prozessmoderator des Super-Kreises erhält ein Projekt, das ordentliche Verfahren im Kreis wiederherzustellen; und
+- **(c)** der Prozessmoderator des Super-Kreises erhält die Befugnis, als Prozessmoderator oder Kreis-Sekretär des Kreises zu übernehmen; und
+- **(d)** der Prozessmoderator des Super-Kreises darf für die Dauer des Prozessversagens einen zusätzlichen Kreis-Lead zuweisen. Alle Entscheidungen, die diese Person als Kreis-Lead trifft, übertrumpfen und verhindern alle widersprechenden Entscheidungen eines anderen Kreis-Leads.
 
-Diese Befugnisse enden, sobald entsprechend der Einschätzung des\*der Prozessmoderators\*in des Super-Kreises das ordentliche Verfahren im Kreis wieder hergestellt ist.
+Diese Befugnisse enden, sobald entsprechend der Einschätzung des Prozessmoderators des Super-Kreises das ordentliche Verfahren im Kreis wieder hergestellt ist.
 
-Falls der Kreis, der sich im Prozessversagen befindet, keinen Super-Kreis hat, dann gehen stattdessen alle obigen Befugnisse auf seine\*n eigene\*n Prozessmoderator\*in über.
+Falls der Kreis, der sich im Prozessversagen befindet, keinen Super-Kreis hat, dann gehen stattdessen alle obigen Befugnisse auf seinen eigenen Prozessmoderator über.
 
 
 #### 5.5.3 Eskalation eines Prozessversagens


### PR DESCRIPTION
closes https://github.com/holacracyone/Holacracy-Constitution-5.0-GERMAN/issues/4

[As suggested](https://github.com/holacracyone/Holacracy-Constitution-5.0-GERMAN/issues/4#issuecomment-1016636548) by @brianjrobertson, this translation uses standard legal German:

> And beyond that, all of the recent posts leave me feeling quite confident that the best approach here for the goals/needs of the constitution is to completely ignore the politics and broader cultural issues at play to the fullest extent possible, and do whatever a typical lawyer in the culture would do by default if drafting a legal document for a client with absolutely zero regard for any cultural sensitivity or cultural change/evolution goals whatsoever 

See also [my final comment](https://github.com/holacracyone/Holacracy-Constitution-5.0-GERMAN/issues/4#issuecomment-1016885691) in the related issue.


**Note**: I have created [a python  script to remove the gendersternchen](https://gist.github.com/geek-42/e1851d26e24a07646e8f0f486fa12f30)  automatically. Therefore, the result needs manual review (I am programmer and not translator 😉).

**Note**: The text may need a preamble explaining that the generic masculine is used for readability and simplicity and that it is meant to be inclusive....